### PR TITLE
Fix `find_guild` function to ignore mismatched timestamps on member data

### DIFF
--- a/src/model/guild.rs
+++ b/src/model/guild.rs
@@ -1782,7 +1782,7 @@ impl Member {
 
             let predicate = guild.members
                 .values()
-                .any(|m| m.joined_at == self.joined_at && m.user.read().unwrap().id == self.user.read().unwrap().id);
+                .any(|m| m.user.read().unwrap().id == self.user.read().unwrap().id);
 
             if predicate {
                 return Ok(guild.id);
@@ -1857,7 +1857,7 @@ impl Member {
                 .unwrap()
                 .members
                 .values()
-                .any(|m| m.user.read().unwrap().id == self.user.read().unwrap().id && m.joined_at == *self.joined_at))
+                .any(|m| m.user.read().unwrap().id == self.user.read().unwrap().id))
             .map(|guild| guild
                 .read()
                 .unwrap()


### PR DESCRIPTION
This fixes issues with various `Member` functions such as `add_role` or `ban`
which refused to work on some users due to their joined_at timestamp being
slightly different over REST requests.

As an example in the guild create event i got the following data for a member:
```
{
    "deaf": false,
    "joined_at": "2017-03-18T10:33:46.521254+00:00",
    "mute": false,
    "nick": null,
    "roles": [],
    "user": {
        "avatar": null,
        "discriminator": "4321",
        "id": "1234",
        "username": "blah"
    }
}
```

A following REST request triggered by `get_member` then got this response shortly after:
```
{
    "deaf": false,
    "joined_at": "2017-03-18T10:33:46.521000+00:00",
    "mute": false,
    "roles": [],
    "user": {
        "avatar": null,
        "discriminator": "4321",
        "id": "1234",
        "username": "blah"
    }
}
```

The `joined_at` timestamps are slightly different and due to that the `find_guild` function would fail to find this member. Many of the functions in `Member` depend on it and will not work on some users where this occurs.

To fix it i just removed the timestamp comparison, from what i know the discord API guarantees the user id's to be unique so there should be no need for it.