### PR TITLE
Fix deadlock/panic on channel create event for private messages

### DIFF
--- a/src/ext/cache/mod.rs
+++ b/src/ext/cache/mod.rs
@@ -580,7 +580,7 @@ impl Cache {
 
                 channel_writer.recipient = self.users[&user_id].clone();
 
-                let ch = self.private_channels.insert(channel.read().unwrap().id, channel.clone());
+                let ch = self.private_channels.insert(channel_writer.id, channel.clone());
                 ch.map(Channel::Private)
             },
         }


### PR DESCRIPTION
Here is another one. Lets see what i missed this time :P

In `update_with_channel_create` for the `Private` branch we have this:
```
let mut channel_writer = channel.write().unwrap();
...
let ch = self.private_channels.insert(channel.read().unwrap().id, channel.clone());
```

Obtaining the read lock will fail since there already is a write active for the same object. As it happens in the same thread this would be a deadlock but panics instead. It is easy to reproduce as it always occurs on the first private message from a new user (for which no DM channel is open already).


```
thread '<unnamed>' panicked at 'rwlock read lock would result in deadlock', /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sys/unix/rwlock.rs:59
stack backtrace:
   1:     0x7f61ede601ac - std::sys::imp::backtrace::tracing::imp::write::hf33ae72d0baa11ed
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:42
   2:     0x7f61ede6349e - std::panicking::default_hook::{{closure}}::h59672b733cc6a455
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:351
   3:     0x7f61ede630a4 - std::panicking::default_hook::h1670459d2f3f8843
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:367
   4:     0x7f61ede6393b - std::panicking::rust_panic_with_hook::hcf0ddb069e7beee7
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:555
   5:     0x7f61eda7d503 - std::panicking::begin_panic::h571af2e8f9db4a41
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:517
   6:     0x7f61eda479d6 - std::sys::imp::rwlock::RWLock::read::ha2a515456dfa420f
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/macros.rs:44
   7:     0x7f61eda217ec - std::sys_common::rwlock::RWLock::read::h9074ed79ed408e5e
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sys_common/rwlock.rs:33
   8:     0x7f61edaa2cea - <std::sync::rwlock::RwLock<T>>::read::h86d1f13142e15f91
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sync/rwlock.rs:161
   9:     0x7f61edc7877f - serenity::ext::cache::Cache::update_with_channel_create::h149add1bca5f6b4c
                        at /tmp/serenity/src/ext/cache/mod.rs:583
  10:     0x7f61edc5e9d3 - serenity::client::dispatch::handle_event::hd8e593824e142b0e
                        at /tmp/serenity/src/client/dispatch.rs:193
  11:     0x7f61edc5b41c - serenity::client::dispatch::dispatch::h8b90049df0e9975e
                        at /tmp/serenity/src/client/dispatch.rs:94
  12:     0x7f61edc769c7 - serenity::client::handle_shard::hf300c9d63b99541f
                        at /tmp/serenity/src/client/mod.rs:1350
  13:     0x7f61edc74c5f - serenity::client::monitor_shard::h45f510515fdc0b0d
                        at /tmp/serenity/src/client/mod.rs:1248
  14:     0x7f61edc7390d - serenity::client::Client::start_connection::{{closure}}::ha7176baa9f3d2510
                        at /tmp/serenity/src/client/mod.rs:845
  15:     0x7f61edc25bda - <std::panic::AssertUnwindSafe<F> as core::ops::FnOnce<()>>::call_once::hfc94616ce5e4fc19
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panic.rs:296
  16:     0x7f61eda8c719 - std::panicking::try::do_call::h7e0b737e720a3a27
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:460
  17:     0x7f61ede6a85a - __rust_maybe_catch_panic
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libpanic_unwind/lib.rs:98
  18:     0x7f61eda7f813 - std::panicking::try::h4bfd893ab9cc4a1f
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panicking.rs:436
  19:     0x7f61eda4a2a4 - std::panic::catch_unwind::h97991a88604d74e1
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/panic.rs:361
  20:     0x7f61eda7b55b - std::thread::Builder::spawn::{{closure}}::hd82c91e91db0c910
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/thread/mod.rs:357
  21:     0x7f61edb10dd2 - <F as alloc::boxed::FnBox<A>>::call_box::h9212551dc1fcebc4
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/liballoc/boxed.rs:614
  22:     0x7f61ede628f4 - std::sys::imp::thread::Thread::new::thread_start::he668872ac11287ba
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/liballoc/boxed.rs:624
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sys_common/thread.rs:21
                        at /buildslave/rust-buildbot/slave/stable-dist-rustc-linux/build/src/libstd/sys/unix/thread.rs:84
  23:     0x7f61ec99d063 - start_thread
  24:     0x7f61ec4bc62c - clone
  25:                0x0 - <unknown>
```