### PR TITLE
Check if message starts with dynamic_prefix result.

### DIFF
--- a/src/ext/framework/command.rs
+++ b/src/ext/framework/command.rs
@@ -102,7 +102,9 @@ pub fn positions(ctx: &mut Context, content: &str, conf: &Configuration) -> Opti
             positions.push(mention_end);
         } else if let Some(ref func) = conf.dynamic_prefix {
             if let Some(x) = func(ctx) {
-                positions.push(x.len());
+                if content.starts_with(&x) {
+                    positions.push(x.len());
+                }
             } else {
                 for n in conf.prefixes.clone() {
                     if content.starts_with(&n) {


### PR DESCRIPTION
I believe this fixes my issue with dynamic_prefix not changing when I update my HashMap. With this in place, only one prefix works at a time as intended.