### PR TITLE
Trim content before parsing args

### DIFF
--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -477,10 +477,13 @@ impl Framework {
                         let after = self.after.clone();
                         let groups = self.groups.clone();
 
+                        let content = message.content[position..].to_owned();
+                        let content = content.trim();
+
                         let args = if command.use_quotes {
-                            utils::parse_quotes(&message.content[position + command_length..])
+                            utils::parse_quotes(&content[command_length..])
                         } else {
-                            message.content[position + command_length..]
+                            content[command_length..]
                                 .split_whitespace()
                                 .map(|arg| arg.to_owned())
                                 .collect::<Vec<String>>()

--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -479,6 +479,7 @@ impl Framework {
 
                         let args = {
                             let content = message.content[position..].trim();
+
                             if command.use_quotes {
                                 utils::parse_quotes(&content[command_length..])
                             } else {

--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -477,16 +477,16 @@ impl Framework {
                         let after = self.after.clone();
                         let groups = self.groups.clone();
 
-                        let content = message.content[position..].to_owned();
-                        let content = content.trim();
-
-                        let args = if command.use_quotes {
-                            utils::parse_quotes(&content[command_length..])
-                        } else {
-                            content[command_length..]
-                                .split_whitespace()
-                                .map(|arg| arg.to_owned())
-                                .collect::<Vec<String>>()
+                        let args = {
+                            let content = message.content[position..].trim();
+                            if command.use_quotes {
+                                utils::parse_quotes(&content[command_length..])
+                            } else {
+                                content[command_length..]
+                                    .split_whitespace()
+                                    .map(|arg| arg.to_owned())
+                                    .collect::<Vec<String>>()
+                            }
                         };
 
                         if let Some(error) = self.should_fail(&mut context, &message, &command, args.len(), &to_check, &built) {


### PR DESCRIPTION
Fixes #76 according to my tests. However, if there is a better way to do this feel free to change it.