### PR TITLE
Don't skip everyone role when checking channel overwrites.

### DIFF
--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -477,10 +477,13 @@ impl Framework {
                         let after = self.after.clone();
                         let groups = self.groups.clone();
 
+                        let content = message.content[position..].to_owned();
+                        let content = content.trim();
+
                         let args = if command.use_quotes {
-                            utils::parse_quotes(&message.content[position + command_length..])
+                            utils::parse_quotes(&content[command_length..])
                         } else {
-                            message.content[position + command_length..]
+                            content[command_length..]
                                 .split_whitespace()
                                 .map(|arg| arg.to_owned())
                                 .collect::<Vec<String>>()

--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -479,6 +479,7 @@ impl Framework {
 
                         let args = {
                             let content = message.content[position..].trim();
+
                             if command.use_quotes {
                                 utils::parse_quotes(&content[command_length..])
                             } else {

--- a/src/ext/framework/mod.rs
+++ b/src/ext/framework/mod.rs
@@ -477,16 +477,16 @@ impl Framework {
                         let after = self.after.clone();
                         let groups = self.groups.clone();
 
-                        let content = message.content[position..].to_owned();
-                        let content = content.trim();
-
-                        let args = if command.use_quotes {
-                            utils::parse_quotes(&content[command_length..])
-                        } else {
-                            content[command_length..]
-                                .split_whitespace()
-                                .map(|arg| arg.to_owned())
-                                .collect::<Vec<String>>()
+                        let args = {
+                            let content = message.content[position..].trim();
+                            if command.use_quotes {
+                                utils::parse_quotes(&content[command_length..])
+                            } else {
+                                content[command_length..]
+                                    .split_whitespace()
+                                    .map(|arg| arg.to_owned())
+                                    .collect::<Vec<String>>()
+                            }
                         };
 
                         if let Some(error) = self.should_fail(&mut context, &message, &command, args.len(), &to_check, &built) {

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -794,7 +794,7 @@ impl Guild {
             // Roles
             for overwrite in &channel.permission_overwrites {
                 if let PermissionOverwriteType::Role(role) = overwrite.kind {
-                    if !member.roles.contains(&role) || role.0 == self.id.0 {
+                    if !member.roles.contains(&role) && role.0 != self.id.0 {
                         continue;
                     }
 

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -794,7 +794,7 @@ impl Guild {
             // Roles
             for overwrite in &channel.permission_overwrites {
                 if let PermissionOverwriteType::Role(role) = overwrite.kind {
-                    if !member.roles.contains(&role) && role.0 != self.id.0 {
+                    if role.0 != self.id.0 && !member.roles.contains(&role) {
                         continue;
                     }
 


### PR DESCRIPTION
I came across this issue while trying to check permissions using `permissions_for`. I found out that if I made the **everyone** role disable attaching images, my bot would still attempt to attach them even with the check. This seemed to be because `permissions_for` skips the **everyone** role explicitly. All this PR does is make it check that role as well.