### PR TITLE
Add support for retrieving invites with counts

### DIFF
--- a/src/client/rest/mod.rs
+++ b/src/client/rest/mod.rs
@@ -1136,9 +1136,15 @@ pub fn get_guilds(target: &GuildPagination, limit: u64) -> Result<Vec<GuildInfo>
 }
 
 /// Gets information about a specific invite.
-pub fn get_invite(code: &str) -> Result<Invite> {
+pub fn get_invite(code: &str, stats: bool) -> Result<Invite> {
     let invite = ::utils::parse_invite(code);
-    let response = request!(Route::InvitesCode, get, "/invites/{}", invite);
+    let mut uri = format!("/invites/{}", invite);
+
+    if stats {
+        uri.push_str("?with_counts=true");
+    }
+
+    let response = request!(Route::InvitesCode, get, "{}", uri);
 
     serde_json::from_reader::<HyperResponse, Invite>(response).map_err(From::from)
 }

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -121,6 +121,8 @@ pub struct InviteGuild {
     pub icon: Option<String>,
     pub name: String,
     pub splash_hash: Option<String>,
+    pub text_channel_count: Option<u64>,
+    pub voice_channel_count: Option<u64>,
 }
 
 impl InviteGuild {

--- a/src/model/invite.rs
+++ b/src/model/invite.rs
@@ -14,6 +14,19 @@ use super::utils as model_utils;
 /// Information can not be accessed for guilds the current user is banned from.
 #[derive(Clone, Debug, Deserialize)]
 pub struct Invite {
+    /// The approximate number of [`Member`]s in the related [`Guild`].
+    ///
+    /// [`Guild`]: struct.Guild.html
+    /// [`Member`]: struct.Member.html
+    pub approximate_member_count: Option<u64>,
+    /// The approximate number of [`Member`]s with an active session in the
+    /// related [`Guild`].
+    ///
+    /// An active session is defined as an open, heartbeating WebSocket connection.
+    /// These include [invisible][`OnlineStatus::Invisible`] members.
+    ///
+    /// [`OnlineStatus::Invisible`]: enum.OnlineStatus.html#variant.Invisible
+    pub approximate_presence_count: Option<u64>,
     /// The unique code for the invite.
     pub code: String,
     /// A representation of the minimal amount of information needed about the
@@ -23,8 +36,6 @@ pub struct Invite {
     pub channel: InviteChannel,
     /// a representation of the minimal amount of information needed about the
     /// [`Guild`] being invited to.
-    ///
-    /// [`Guild`]: struct.Guild.html
     pub guild: InviteGuild,
 }
 
@@ -89,8 +100,8 @@ impl Invite {
     }
 
     /// Gets the information about an invite.
-    pub fn get(code: &str) -> Result<Invite> {
-        rest::get_invite(utils::parse_invite(code))
+    pub fn get(code: &str, stats: bool) -> Result<Invite> {
+        rest::get_invite(utils::parse_invite(code), stats)
     }
 }
 


### PR DESCRIPTION
Previously retrieving an invite with the `?with_counts=true` wasn't possible.

Added support to `get_invite` for retrieving an invite with the counts, this requires the user to pass true to the function.
The counts include `approximate_presence_count` and `approximate_member_count` which have been added to the `Invite` stuct.

Done in response to: https://github.com/zeyla/serenity/issues/83