### PR TITLE
Fix call to VoiceManager.join in examples/06_voice

### DIFF
--- a/examples/06_voice/src/main.rs
+++ b/examples/06_voice/src/main.rs
@@ -99,7 +99,7 @@ command!(join(ctx, msg, args) {
     };
 
     let mut shard = ctx.shard.lock().unwrap();
-    shard.manager.join(Some(guild_id), connect_to);
+    shard.manager.join(guild_id, connect_to);
 
     check_msg(msg.channel_id.say(&format!("Joined {}", connect_to.mention())));
 });


### PR DESCRIPTION
`VoiceManager.join(&mut self, guild_id: Option<GuildId>, ...)`
has been changed to
`VoiceManager.join<G>(&mut self, guild_id: G, ...) where G: Into<GuildId>`.
 
We should no longer wrap `guild_id` with `Some`.