### PR TITLE
Add invite_url method

### DIFF
--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -103,6 +103,18 @@ impl CurrentUser {
         self.avatar.as_ref()
             .map(|av| format!(cdn!("/avatars/{}/{}.webp?size=1024"), self.id.0, av))
     }
+
+    /// Returns the invite url for the bot with the given permissions.
+    ///
+    /// If the permissions passed are empty, the permissions part will be dropped.
+    pub fn invite_url(&self, permissions: Permissions) -> String {
+        let bits = permissions.bits();
+        if bits == 0 {
+            format!("https://discordapp.com/api/oauth2/authorize?client_id={}&scope=bot", self.id)
+        } else {
+            format!("https://discordapp.com/api/oauth2/authorize?client_id={}&scope=bot&permissions={}", self.id, bits)
+        }
+    }
 }
 
 /// An enum that represents a default avatar.


### PR DESCRIPTION
Basic implementation, open to changes.

Usage:

```rust
use serenity::client::CACHE;
use serenity::model::permissions::*;
let cache = CACHE.read().expect("Could not read cache.");

// Pass empty permissions to get a url without the added "&permissions=" section
let no_perm_url = cache.user.invite_url(Permissions::empty());

// Pass in permissions to get them added to the end of the url.
let perm_url = cache.user.invite_url(READ_MESSAGES | SEND_MESSAGES);
```