### PR TITLE
Add Content for MessageBuilder

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+[.travis.yml]
+indent_style = space
+indent_size = 2

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1,8 +1,7 @@
 use std::default::Default;
 use std::fmt::{self, Write};
-use ::model::{ChannelId, Emoji, Mentionable, RoleId, UserId};
 use std::ops::Add;
-use std::convert::{From, Into};
+use ::model::{ChannelId, Emoji, Mentionable, RoleId, UserId};
 
 /// The Message Builder is an ergonomic utility to easily build a message,
 /// by adding text and mentioning mentionable structs.
@@ -728,7 +727,7 @@ impl fmt::Display for MessageBuilder {
 }
 
 
-/// Content modifier enum
+/// Formatting modifiers for MessageBuilder content pushes
 ///
 /// Provides an enum of formatting modifiers for a string, for combination with
 /// string types and Content types.
@@ -737,178 +736,221 @@ impl fmt::Display for MessageBuilder {
 ///
 /// Create a new Content type which describes a bold-italic "text":
 ///
-/// ```rust
-/// use serenity::utils::{Bold, Italic, Content};
+/// ```rust,no_run
+/// use serenity::utils::ContentModifier::{Bold, Italic};
+/// use serenity::utils::Content;
 /// let content: Content = Bold + Italic + "text";
 /// ```
 pub enum ContentModifier {
-  Italic,
-  Bold,
-  Strikethrough,
-  Code,
-  Underline
+    Italic,
+    Bold,
+    Strikethrough,
+    Code,
+    Underline
 }
 
 /// Describes formatting on string content
 #[derive(Default, Clone)]
 pub struct Content {
-  italic: bool,
-  bold: bool,
-  strikethrough: bool,
-  pub inner: String,
-  code: bool,
-  underline: bool
+    pub italic: bool,
+    pub bold: bool,
+    pub strikethrough: bool,
+    pub inner: String,
+    pub code: bool,
+    pub underline: bool
 }
 
 impl Add<String> for Content {
-  type Output = Content;
-  fn add(self, rhs: String) -> Content {
-    let mut nc = self.clone();
-    nc.inner = nc.inner + &rhs;
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: String) -> Content {
+        let mut nc = self.clone();
+        nc.inner = nc.inner + &rhs;
+
+        nc
+    }
+
 }
 
 impl<'a> Add<&'a str> for Content {
-  type Output = Content;
-  fn add(self, rhs: &str) -> Content {
-    let mut nc = self.clone();
-    nc.inner = nc.inner + rhs;
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: &str) -> Content {
+        let mut nc = self.clone();
+        nc.inner = nc.inner + rhs;
+
+        nc
+    }
+
 }
 
 impl Add<String> for ContentModifier {
-  type Output = Content;
-  fn add(self, rhs: String) -> Content {
-    let mut nc = self.to_content();
-    nc.inner = nc.inner + &rhs;
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: String) -> Content {
+        let mut nc = self.to_content();
+        nc.inner = nc.inner + &rhs;
+
+        nc
+    }
+
 }
 
 impl<'a> Add<&'a str> for ContentModifier {
-  type Output = Content;
-  fn add(self, rhs: &str) -> Content {
-    let mut nc = self.to_content();
-    nc.inner = nc.inner + rhs;
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: &str) -> Content {
+        let mut nc = self.to_content();
+        nc.inner = nc.inner + rhs;
+
+        nc
+    }
+
 }
 
 impl Add<ContentModifier> for Content {
-  type Output = Content;
-  fn add(self, rhs: ContentModifier) -> Content {
-    let mut nc = self.clone();
-    nc.apply(&rhs);
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: ContentModifier) -> Content {
+        let mut nc = self.clone();
+        nc.apply(&rhs);
+
+        nc
+    }
+
 }
 
 impl Add<ContentModifier> for ContentModifier {
-  type Output = Content;
-  fn add(self, rhs: ContentModifier) -> Content {
-    let mut nc = self.to_content();
-    nc.apply(&rhs);
-    nc
-  }
+    type Output = Content;
+
+    fn add(self, rhs: ContentModifier) -> Content {
+        let mut nc = self.to_content();
+        nc.apply(&rhs);
+
+        nc
+    }
+
 }
 
 impl ContentModifier {
-  fn to_content(&self) -> Content {
-    let mut nc = Content::default();
-    nc.apply(self);
-    nc
-  }
+
+    fn to_content(&self) -> Content {
+      let mut nc = Content::default();
+      nc.apply(self);
+
+      nc
+    }
+
 }
 
 impl Content {
-  pub fn apply(&mut self, modifier: &ContentModifier) {
-    match *modifier {
-      ContentModifier::Italic => {
-        self.italic = true;
-      },
-      ContentModifier::Bold => {
-        self.bold = true;
-      },
-      ContentModifier::Strikethrough => {
-        self.strikethrough = true;
-      },
-      ContentModifier::Code => {
-        self.code = true;
-      },
-      ContentModifier::Underline => {
-        self.underline = true;
-      }
+
+    pub fn apply(&mut self, modifier: &ContentModifier) {
+        match *modifier {
+            ContentModifier::Italic => {
+                self.italic = true;
+            },
+            ContentModifier::Bold => {
+                self.bold = true;
+            },
+            ContentModifier::Strikethrough => {
+                self.strikethrough = true;
+            },
+            ContentModifier::Code => {
+                self.code = true;
+            },
+            ContentModifier::Underline => {
+                self.underline = true;
+            }
+        }
     }
-  }
-  pub fn to_string(&self) -> String {
-    let mut newstr = String::with_capacity(
-      self.inner.len()
-      + if self.bold {4} else {0}
-      + if self.italic {2} else {0}
-      + if self.strikethrough {4} else {0}
-      + if self.underline {4} else {0}
-      + if self.code {2} else {0}
-    );
-    if self.bold {
-      newstr.push_str("**");
+
+    pub fn to_string(&self) -> String {
+        let mut newstr = String::with_capacity(
+            self.inner.len()
+                + if self.bold { 4 } else { 0 }
+                + if self.italic { 2 } else { 0 }
+                + if self.strikethrough { 4 } else { 0 }
+                + if self.underline { 4 } else { 0 }
+                + if self.code { 2 } else { 0 }
+        );
+
+        if self.bold {
+            newstr.push_str("**");
+        }
+
+        if self.italic {
+            newstr.push('*');
+        }
+
+        if self.strikethrough {
+            newstr.push_str("~~");
+        }
+
+        if self.underline {
+            newstr.push_str("__");
+        }
+
+        if self.code {
+            newstr.push('`');
+        }
+
+        newstr.push_str(&self.inner);
+
+        if self.code {
+            newstr.push('`');
+        }
+
+        if self.underline {
+            newstr.push_str("__");
+        }
+
+        if self.strikethrough {
+            newstr.push_str("~~");
+        }
+
+        if self.italic {
+            newstr.push('*');
+        }
+
+        if self.bold {
+            newstr.push_str("**");
+        }
+
+        newstr
     }
-    if self.italic {
-      newstr.push_str("*");
-    }
-    if self.strikethrough {
-      newstr.push_str("~~");
-    }
-    if self.underline {
-      newstr.push_str("__");
-    }
-    if self.code {
-      newstr.push_str("`");
-    }
-    newstr.push_str(&self.inner);
-    if self.code {
-      newstr.push_str("`");
-    }
-    if self.underline {
-      newstr.push_str("__");
-    }
-    if self.strikethrough {
-      newstr.push_str("~~");
-    }
-    if self.italic {
-      newstr.push_str("*");
-    }
-    if self.bold {
-      newstr.push_str("**");
-    }
-    newstr
-  }
+
 }
 
 impl From<String> for Content {
-  fn from(s: String) -> Content {
-    Content {
-      italic: false,
-      bold: false,
-      strikethrough: false,
-      inner: s,
-      code: false,
-      underline: false
+
+    fn from(s: String) -> Content {
+        Content {
+            italic: false,
+            bold: false,
+            strikethrough: false,
+            inner: s,
+            code: false,
+            underline: false
+        }
     }
-  }
+
 }
 
 impl<'a> From<&'a str> for Content {
-  fn from(s: &str) -> Content {
-    Content::from(s.to_owned())
-  }
+
+    fn from(s: &str) -> Content {
+        Content::from(s.to_owned())
+    }
+
 }
 
 impl From<ContentModifier> for Content {
-  fn from(cm: ContentModifier) -> Content {
-    cm.to_content()
-  }
+
+    fn from(cm: ContentModifier) -> Content {
+        cm.to_content()
+    }
+    
 }
 
 fn normalize(text: &str) -> String {

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -194,7 +194,7 @@ impl MessageBuilder {
     /// assert_eq!(message.push("ing").0, "testing");
     /// ```
     pub fn push<T: Into<Content>>(mut self, content: T) -> Self {
-        let content: Content = content.into();
+        let content = content.into();
         self.0.push_str(&content.to_string());
 
         self
@@ -950,7 +950,7 @@ impl From<ContentModifier> for Content {
     fn from(cm: ContentModifier) -> Content {
         cm.to_content()
     }
-    
+
 }
 
 fn normalize(text: &str) -> String {

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -1,5 +1,5 @@
 use std::default::Default;
-use std::fmt::{self, Write};
+use std::fmt::{self, Write, Display};
 use std::ops::Add;
 use ::model::{ChannelId, Emoji, Mentionable, RoleId, UserId};
 
@@ -706,7 +706,7 @@ impl MessageBuilder {
     }
 }
 
-impl fmt::Display for MessageBuilder {
+impl Display for MessageBuilder {
     /// Formats the message builder into a string.
     ///
     /// This is done by simply taking the internal value of the tuple-struct and
@@ -784,6 +784,17 @@ impl<'a> Add<&'a str> for Content {
 
 }
 
+impl<T: ToString> Add<T> for Content {
+    type Output = Content;
+
+    fn add(self, rhs: T) -> Content {
+        let mut nc = self.clone();
+        nc.inner = nc.inner + rhs.to_string();
+
+        nc
+    }
+}
+
 impl Add<String> for ContentModifier {
     type Output = Content;
 
@@ -806,6 +817,17 @@ impl<'a> Add<&'a str> for ContentModifier {
         nc
     }
 
+}
+
+impl<T: ToString> Add<T> for ContentModifier {
+    type Output = Content;
+
+    fn add(self, rhs: T) -> Content {
+        let mut nc = self.to_content();
+        nc.inner = nc.inner + rhs.to_string();
+
+        nc
+    }
 }
 
 impl Add<ContentModifier> for Content {
@@ -865,60 +887,64 @@ impl Content {
         }
     }
 
-    pub fn to_string(&self) -> String {
-        let mut newstr = String::with_capacity(
-            self.inner.len()
-                + if self.bold { 4 } else { 0 }
-                + if self.italic { 2 } else { 0 }
-                + if self.strikethrough { 4 } else { 0 }
-                + if self.underline { 4 } else { 0 }
-                + if self.code { 2 } else { 0 }
-        );
+}
 
-        if self.bold {
-            newstr.push_str("**");
-        }
+impl Display for Content {
 
-        if self.italic {
-            newstr.push('*');
-        }
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+      let mut newstr = String::with_capacity(
+          self.inner.len()
+              + if self.bold { 4 } else { 0 }
+              + if self.italic { 2 } else { 0 }
+              + if self.strikethrough { 4 } else { 0 }
+              + if self.underline { 4 } else { 0 }
+              + if self.code { 2 } else { 0 }
+      );
 
-        if self.strikethrough {
-            newstr.push_str("~~");
-        }
+      if self.bold {
+          newstr.push_str("**");
+      }
 
-        if self.underline {
-            newstr.push_str("__");
-        }
+      if self.italic {
+          newstr.push('*');
+      }
 
-        if self.code {
-            newstr.push('`');
-        }
+      if self.strikethrough {
+          newstr.push_str("~~");
+      }
 
-        newstr.push_str(&self.inner);
+      if self.underline {
+          newstr.push_str("__");
+      }
 
-        if self.code {
-            newstr.push('`');
-        }
+      if self.code {
+          newstr.push('`');
+      }
 
-        if self.underline {
-            newstr.push_str("__");
-        }
+      newstr.push_str(&self.inner);
 
-        if self.strikethrough {
-            newstr.push_str("~~");
-        }
+      if self.code {
+          newstr.push('`');
+      }
 
-        if self.italic {
-            newstr.push('*');
-        }
+      if self.underline {
+          newstr.push_str("__");
+      }
 
-        if self.bold {
-            newstr.push_str("**");
-        }
+      if self.strikethrough {
+          newstr.push_str("~~");
+      }
 
-        newstr
-    }
+      if self.italic {
+          newstr.push('*');
+      }
+
+      if self.bold {
+          newstr.push_str("**");
+      }
+
+      write!(f, "{}", newstr)
+  }
 
 }
 
@@ -949,6 +975,21 @@ impl From<ContentModifier> for Content {
 
     fn from(cm: ContentModifier) -> Content {
         cm.to_content()
+    }
+
+}
+
+impl<T: ToString> From<T> for Content {
+
+    fn from(stringer: T) -> Content {
+        Content {
+            italic: false,
+            bold: false,
+            strikethrough: false,
+            inner: stringer.to_string(),
+            code: false,
+            underline: false
+        }
     }
 
 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -746,7 +746,7 @@ pub enum ContentModifier {
     Bold,
     Strikethrough,
     Code,
-    Underline
+    Underline,
 }
 
 /// Describes formatting on string content
@@ -791,7 +791,6 @@ impl Add<ContentModifier> for Content {
 
         nc
     }
-
 }
 
 impl Add<ContentModifier> for ContentModifier {
@@ -803,22 +802,18 @@ impl Add<ContentModifier> for ContentModifier {
 
         nc
     }
-
 }
 
 impl ContentModifier {
-
     fn to_content(&self) -> Content {
       let mut nc = Content::default();
       nc.apply(self);
 
       nc
     }
-
 }
 
 impl Content {
-
     pub fn apply(&mut self, modifier: &ContentModifier) {
         match *modifier {
             ContentModifier::Italic => {
@@ -835,77 +830,72 @@ impl Content {
             },
             ContentModifier::Underline => {
                 self.underline = true;
-            }
+            },
         }
     }
 
     pub fn to_string(&self) -> String {
-        let mut newstr = String::with_capacity(
-            self.inner.len()
-                + if self.bold { 4 } else { 0 }
-                + if self.italic { 2 } else { 0 }
-                + if self.strikethrough { 4 } else { 0 }
-                + if self.underline { 4 } else { 0 }
-                + if self.code { 2 } else { 0 }
-        );
+        let capacity = self.inner.len()
+            + if self.bold { 4 } else { 0 }
+            + if self.italic { 2 } else { 0 }
+            + if self.strikethrough { 4 } else { 0 }
+            + if self.underline { 4 } else { 0 }
+            + if self.code { 2 } else { 0 };
+        let mut new_str = String::with_capacity(capacity);
 
         if self.bold {
-            newstr.push_str("**");
+            new_str.push_str("**");
         }
 
         if self.italic {
-            newstr.push('*');
+            new_str.push('*');
         }
 
         if self.strikethrough {
-            newstr.push_str("~~");
+            new_str.push_str("~~");
         }
 
         if self.underline {
-            newstr.push_str("__");
+            new_str.push_str("__");
         }
 
         if self.code {
-            newstr.push('`');
+            new_str.push('`');
         }
 
-        newstr.push_str(&self.inner);
+        new_str.push_str(&self.inner);
 
         if self.code {
-            newstr.push('`');
+            new_str.push('`');
         }
 
         if self.underline {
-            newstr.push_str("__");
+            new_str.push_str("__");
         }
 
         if self.strikethrough {
-            newstr.push_str("~~");
+            new_str.push_str("~~");
         }
 
         if self.italic {
-            newstr.push('*');
+            new_str.push('*');
         }
 
         if self.bold {
-            newstr.push_str("**");
+            new_str.push_str("**");
         }
 
-        newstr
+        new_str
     }
-
 }
 
 impl From<ContentModifier> for Content {
-
     fn from(cm: ContentModifier) -> Content {
         cm.to_content()
     }
-
 }
 
 impl<T: ToString> From<T> for Content {
-
     fn from(stringer: T) -> Content {
         Content {
             italic: false,
@@ -913,10 +903,9 @@ impl<T: ToString> From<T> for Content {
             strikethrough: false,
             inner: stringer.to_string(),
             code: false,
-            underline: false
+            underline: false,
         }
     }
-
 }
 
 fn normalize(text: &str) -> String {

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -839,7 +839,7 @@ impl Content {
         }
     }
 
-    fn to_string(&self) -> String {
+    pub fn to_string(&self) -> String {
         let mut newstr = String::with_capacity(
             self.inner.len()
                 + if self.bold { 4 } else { 0 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -760,63 +760,15 @@ pub struct Content {
     pub underline: bool
 }
 
-impl Add<String> for Content {
-    type Output = Content;
-
-    fn add(self, rhs: String) -> Content {
-        let mut nc = self.clone();
-        nc.inner = nc.inner + &rhs;
-
-        nc
-    }
-
-}
-
-impl<'a> Add<&'a str> for Content {
-    type Output = Content;
-
-    fn add(self, rhs: &str) -> Content {
-        let mut nc = self.clone();
-        nc.inner = nc.inner + rhs;
-
-        nc
-    }
-
-}
-
 impl<T: ToString> Add<T> for Content {
     type Output = Content;
 
     fn add(self, rhs: T) -> Content {
         let mut nc = self.clone();
-        nc.inner = nc.inner + rhs.to_string();
+        nc.inner = nc.inner + &rhs.to_string();
 
         nc
     }
-}
-
-impl Add<String> for ContentModifier {
-    type Output = Content;
-
-    fn add(self, rhs: String) -> Content {
-        let mut nc = self.to_content();
-        nc.inner = nc.inner + &rhs;
-
-        nc
-    }
-
-}
-
-impl<'a> Add<&'a str> for ContentModifier {
-    type Output = Content;
-
-    fn add(self, rhs: &str) -> Content {
-        let mut nc = self.to_content();
-        nc.inner = nc.inner + rhs;
-
-        nc
-    }
-
 }
 
 impl<T: ToString> Add<T> for ContentModifier {
@@ -824,7 +776,7 @@ impl<T: ToString> Add<T> for ContentModifier {
 
     fn add(self, rhs: T) -> Content {
         let mut nc = self.to_content();
-        nc.inner = nc.inner + rhs.to_string();
+        nc.inner = nc.inner + &rhs.to_string();
 
         nc
     }
@@ -887,86 +839,59 @@ impl Content {
         }
     }
 
-}
+    fn to_string(&self) -> String {
+        let mut newstr = String::with_capacity(
+            self.inner.len()
+                + if self.bold { 4 } else { 0 }
+                + if self.italic { 2 } else { 0 }
+                + if self.strikethrough { 4 } else { 0 }
+                + if self.underline { 4 } else { 0 }
+                + if self.code { 2 } else { 0 }
+        );
 
-impl Display for Content {
-
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      let mut newstr = String::with_capacity(
-          self.inner.len()
-              + if self.bold { 4 } else { 0 }
-              + if self.italic { 2 } else { 0 }
-              + if self.strikethrough { 4 } else { 0 }
-              + if self.underline { 4 } else { 0 }
-              + if self.code { 2 } else { 0 }
-      );
-
-      if self.bold {
-          newstr.push_str("**");
-      }
-
-      if self.italic {
-          newstr.push('*');
-      }
-
-      if self.strikethrough {
-          newstr.push_str("~~");
-      }
-
-      if self.underline {
-          newstr.push_str("__");
-      }
-
-      if self.code {
-          newstr.push('`');
-      }
-
-      newstr.push_str(&self.inner);
-
-      if self.code {
-          newstr.push('`');
-      }
-
-      if self.underline {
-          newstr.push_str("__");
-      }
-
-      if self.strikethrough {
-          newstr.push_str("~~");
-      }
-
-      if self.italic {
-          newstr.push('*');
-      }
-
-      if self.bold {
-          newstr.push_str("**");
-      }
-
-      write!(f, "{}", newstr)
-  }
-
-}
-
-impl From<String> for Content {
-
-    fn from(s: String) -> Content {
-        Content {
-            italic: false,
-            bold: false,
-            strikethrough: false,
-            inner: s,
-            code: false,
-            underline: false
+        if self.bold {
+            newstr.push_str("**");
         }
-    }
 
-}
+        if self.italic {
+            newstr.push('*');
+        }
 
-impl<'a> From<&'a str> for Content {
+        if self.strikethrough {
+            newstr.push_str("~~");
+        }
 
-    fn from(s: &str) -> Content {
-        Content::from(s.to_owned())
+        if self.underline {
+            newstr.push_str("__");
+        }
+
+        if self.code {
+            newstr.push('`');
+        }
+
+        newstr.push_str(&self.inner);
+
+        if self.code {
+            newstr.push('`');
+        }
+
+        if self.underline {
+            newstr.push_str("__");
+        }
+
+        if self.strikethrough {
+            newstr.push_str("~~");
+        }
+
+        if self.italic {
+            newstr.push('*');
+        }
+
+        if self.bold {
+            newstr.push_str("**");
+        }
+
+        newstr
     }
 
 }

--- a/src/utils/message_builder.rs
+++ b/src/utils/message_builder.rs
@@ -357,7 +357,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "hello\nworld");
     /// ```
-    pub fn push_line(mut self, content: &str) -> Self {
+    pub fn push_line<T: Into<Content>>(mut self, content: T) -> Self {
         self = self.push(content);
         self.0.push('\n');
 
@@ -555,7 +555,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(content, "Hello @\u{200B}everyone\nHow are you?");
     /// ```
-    pub fn push_line_safe(mut self, content: &str) -> Self {
+    pub fn push_line_safe<T: Into<Content>>(mut self, content: T) -> Self {
         self = self.push_safe(content);
         self.0.push('\n');
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ mod colour;
 mod message_builder;
 
 pub use self::colour::Colour;
+pub use self::message_builder::{MessageBuilder, Content, ContentModifier};
 
 // Note: Here for BC purposes.
 #[cfg(feature="builder")]
@@ -18,9 +19,6 @@ use std::io::Read;
 use std::path::Path;
 use ::internal::prelude::*;
 use ::model::{EmojiIdentifier, EmojiId};
-
-pub use self::message_builder::{MessageBuilder, Content, ContentModifier};
-pub use self::message_builder::ContentModifier::*;
 
 /// Determines if a name is NSFW.
 ///

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -19,7 +19,8 @@ use std::path::Path;
 use ::internal::prelude::*;
 use ::model::{EmojiIdentifier, EmojiId};
 
-pub use self::message_builder::MessageBuilder;
+pub use self::message_builder::{MessageBuilder, Content, ContentModifier};
+pub use self::message_builder::ContentModifier::*;
 
 /// Determines if a name is NSFW.
 ///

--- a/tests/test_msg_builder.rs
+++ b/tests/test_msg_builder.rs
@@ -1,6 +1,7 @@
 extern crate serenity;
 
-use serenity::utils::MessageBuilder;
+use serenity::utils::{MessageBuilder, Content};
+use serenity::utils::ContentModifier::*;
 use serenity::model::Emoji;
 use serenity::model::EmojiId;
 use serenity::model::UserId;
@@ -50,4 +51,26 @@ fn mentions() {
         .build();
     assert_eq!(content_mentions, "<#1><@2><@&3><@4>");
     assert_eq!(content_emoji, "<:Rohrkatze:32>");
+}
+
+#[test]
+fn content() {
+  let content: Content = Bold + Italic + Code + "Fun!";
+  assert_eq!(content.to_string(), "***`Fun!`***".to_owned());
+}
+
+#[test]
+fn message_content() {
+  let message_content = MessageBuilder::new()
+    .push(Bold + Italic + Code + "Fun!")
+    .build();
+  assert_eq!(message_content, "***`Fun!`***");
+}
+
+#[test]
+fn message_content_safe() {
+  let message_content = MessageBuilder::new()
+    .push_safe(Bold + Italic + "test**test")
+    .build();
+  assert_eq!(message_content, "***test\\*\\*test***");
 }

--- a/tests/test_msg_builder.rs
+++ b/tests/test_msg_builder.rs
@@ -1,6 +1,6 @@
 extern crate serenity;
 
-use serenity::utils::{MessageBuilder, Content};
+use serenity::utils::MessageBuilder;
 use serenity::utils::ContentModifier::*;
 use serenity::model::Emoji;
 use serenity::model::EmojiId;
@@ -55,22 +55,25 @@ fn mentions() {
 
 #[test]
 fn content() {
-  let content: Content = Bold + Italic + Code + "Fun!";
-  assert_eq!(content.to_string(), "***`Fun!`***".to_owned());
+    let content = Bold + Italic + Code + "Fun!";
+
+    assert_eq!(content.to_string(), "***`Fun!`***");
 }
 
 #[test]
 fn message_content() {
-  let message_content = MessageBuilder::new()
-    .push(Bold + Italic + Code + "Fun!")
-    .build();
+    let message_content = MessageBuilder::new()
+        .push(Bold + Italic + Code + "Fun!")
+        .build();
+
   assert_eq!(message_content, "***`Fun!`***");
 }
 
 #[test]
 fn message_content_safe() {
-  let message_content = MessageBuilder::new()
-    .push_safe(Bold + Italic + "test**test")
-    .build();
-  assert_eq!(message_content, "***test\\*\\*test***");
+    let message_content = MessageBuilder::new()
+        .push_safe(Bold + Italic + "test**test")
+        .build();
+
+    assert_eq!(message_content, "***test\\*\\*test***");
 }


### PR DESCRIPTION
This adds a new Content type which `push`, `push_safe`, `push_line`, and `push_line_safe` have been modified to take. This allows for flexible formatting without the duplicated `push_mono`, `push_bold_italic` etc.

```rs
let message_content = MessageBuilder::new()
  .push(Bold + Italic + Code + "text")
  .build()

assert_eq!(message_content, "***`text`***")
```

This should be fairly flexible, and makes sure to apply formatting in the correct order regardless of which order the modifiers are provided. Provides coercions for `&str` and `String`