### PR TITLE
Make CommandOrAlias as well as CommandGroup.commands public

### DIFF
--- a/src/framework/command.rs
+++ b/src/framework/command.rs
@@ -12,7 +12,7 @@ pub type AfterHook = Fn(&mut Context, &Message, &String, Result<(), String>) + S
 pub(crate) type InternalCommand = Arc<Command>;
 pub type PrefixCheck = Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
 
-pub(crate) enum CommandOrAlias {
+pub enum CommandOrAlias {
     Alias(String),
     Command(InternalCommand),
 }
@@ -28,7 +28,7 @@ pub enum CommandType {
 #[derive(Default)]
 pub struct CommandGroup {
     pub prefix: Option<String>,
-    pub(crate) commands: HashMap<String, CommandOrAlias>,
+    pub commands: HashMap<String, CommandOrAlias>,
 }
 
 /// Command struct used to store commands internally.

--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -64,7 +64,7 @@ mod buckets;
 
 pub(crate) use self::buckets::{Bucket, Ratelimit};
 pub use self::command::{Command, CommandType, CommandGroup};
-pub(crate) use self::command::CommandOrAlias;
+pub use self::command::CommandOrAlias;
 pub use self::configuration::Configuration;
 pub use self::create_command::CreateCommand;
 pub use self::create_group::CreateGroup;


### PR DESCRIPTION
In 0.3.0, both `CommandOrAlias` as well as the field `commands` of `CommandGroup` were made private to users outside the crate. While they receive little external use, they are integral to users who wish to create custom help commands (with unique formatting, etc.) 

This PR will make them both public as well as adding a re-export for `CommandOrAlias` in the `framework` module.