### PR TITLE
Fixed clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,12 +89,10 @@
 
 #[macro_use]
 extern crate bitflags;
-#[allow(unused_imports)]
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-#[allow(unused_imports)]
 #[macro_use]
 extern crate serde_json;
 

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -162,7 +162,7 @@ impl Member {
     /// [`guild_id`]: #structfield.guild_id
     #[deprecated(since="0.2.1", note="Use the `guild_id` structfield instead.")]
     pub fn find_guild(&self) -> Result<GuildId> {
-        return Ok(self.guild_id);
+        Ok(self.guild_id)
     }
 
     /// Kick the member from the guild.


### PR DESCRIPTION
Fixed some clippy warnings, didn't touch tests/test_prelude.rs:7:25 because i'm not exactly sure what it does right now.