### PR TITLE
Fixed clippy warnings

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -292,7 +292,7 @@ fn handle_event<H: EventHandler + Send + Sync + 'static>(event: Event,
 
                 let cache = CACHE.read().unwrap();
 
-                if cache.unavailable_guilds.len() == 0 {
+                if cache.unavailable_guilds.is_empty() {
                     let h = event_handler.clone();
 
                     let context = context(conn, data);

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -672,11 +672,11 @@ impl Guild {
     pub fn online_members(&self) -> Vec<&Member> {
         let mut members = vec![];
 
-        for (&id, ref member) in &self.members {
+        for (&id, member) in &self.members {
             match self.presences.get(&id) {
-                Some(ref presence) => {
+                Some(presence) => {
                     if OnlineStatus::Online == presence.status {
-                        members.push(*member);
+                        members.push(member);
                     }
                 },
                 None => continue,


### PR DESCRIPTION
Fixed some clippy warnings, made code more concise.
Clippy also complained about src/client/dispatch.rs:446:36 but i'm not sure if these branches are required for the bot framework so i didn't modify them.