### PR TITLE
Switch to tokio for events

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,10 @@ version = "1.0"
 features = ["serde"]
 version = "~0.4"
 
+[dependencies.futures]
+optional = true
+version = "0.1"
+
 [dependencies.hyper]
 optional = true
 version = "~0.10"
@@ -51,12 +55,19 @@ version = "0.1"
 
 [dependencies.opus]
 optional = true
-version = "0.1"
+version = "0.2"
+
+[dependencies.parking_lot]
+version = "0.4"
 
 [dependencies.sodiumoxide]
 default-features = false
 optional = true
 version = "0.0.12"
+
+[dependencies.tokio-core]
+optional = true
+version = "0.1"
 
 [dependencies.typemap]
 optional = true
@@ -84,7 +95,7 @@ cache = ["lazy_static"]
 client = ["gateway", "lazy_static", "http", "typemap"]
 extras = []
 framework = ["client", "model", "utils"]
-gateway = ["http", "websocket"]
+gateway = ["http", "websocket", "tokio-core", "futures"]
 http = ["hyper", "hyper-native-tls", "lazy_static", "multipart", "native-tls"]
 model = ["builder", "http"]
 utils = []

--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -1,7 +1,8 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use typemap::ShareMap;
 use ::gateway::Shard;
 use ::model::*;
+use parking_lot::Mutex;
 
 #[cfg(feature="cache")]
 use super::CACHE;
@@ -125,7 +126,7 @@ impl Context {
     ///
     /// [`Online`]: ../model/enum.OnlineStatus.html#variant.Online
     pub fn online(&self) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_status(OnlineStatus::Online);
     }
 
@@ -154,7 +155,7 @@ impl Context {
     ///
     /// [`Idle`]: ../model/enum.OnlineStatus.html#variant.Idle
     pub fn idle(&self) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_status(OnlineStatus::Idle);
     }
 
@@ -183,7 +184,7 @@ impl Context {
     ///
     /// [`DoNotDisturb`]: ../model/enum.OnlineStatus.html#variant.DoNotDisturb
     pub fn dnd(&self) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_status(OnlineStatus::DoNotDisturb);
     }
 
@@ -213,7 +214,7 @@ impl Context {
     /// [`Event::Ready`]: ../model/event/enum.Event.html#variant.Ready
     /// [`Invisible`]: ../model/enum.OnlineStatus.html#variant.Invisible
     pub fn invisible(&self) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_status(OnlineStatus::Invisible);
     }
 
@@ -245,7 +246,7 @@ impl Context {
     /// [`Online`]: ../model/enum.OnlineStatus.html#variant.Online
     /// [`set_presence`]: #method.set_presence
     pub fn reset_presence(&self) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_presence(None, OnlineStatus::Online, false)
     }
 
@@ -280,7 +281,7 @@ impl Context {
     ///
     /// [`Online`]: ../model/enum.OnlineStatus.html#variant.Online
     pub fn set_game(&self, game: Game) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_presence(Some(game), OnlineStatus::Online, false);
     }
 
@@ -326,7 +327,7 @@ impl Context {
             url: None,
         };
 
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_presence(Some(game), OnlineStatus::Online, false);
     }
 
@@ -380,7 +381,7 @@ impl Context {
                         game: Option<Game>,
                         status: OnlineStatus,
                         afk: bool) {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.set_presence(game, status, afk)
     }
 
@@ -391,7 +392,7 @@ impl Context {
     ///
     /// [`Client::start`]: ./struct.Client.html#method.start
     pub fn quit(&self) -> Result<()> {
-        let mut shard = self.shard.lock().unwrap();
+        let mut shard = self.shard.lock();
         shard.shutdown_clean()
     }
 }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -526,7 +526,7 @@ impl Shard {
     /// impl EventHandler for Handler {
     ///     fn on_message(&self, ctx: Context, msg: Message) {
     ///         if msg.content == "~ping" {
-    ///             if let Some(latency) = ctx.shard.lock().unwrap().latency() {
+    ///             if let Some(latency) = ctx.shard.lock().latency() {
     ///                 let s = format!("{}.{}s", latency.as_secs(), latency.subsec_nanos());
     ///
     ///                 let _ = msg.channel_id.say(&s);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -104,9 +104,12 @@ extern crate base64;
 extern crate chrono;
 extern crate flate2;
 extern crate serde;
+extern crate parking_lot;
 
 #[cfg(feature="voice")]
 extern crate byteorder;
+#[cfg(feature="futures")]
+extern crate futures;
 #[cfg(feature="hyper")]
 extern crate hyper;
 #[cfg(feature="hyper-native-tls")]
@@ -119,6 +122,8 @@ extern crate native_tls;
 extern crate opus;
 #[cfg(feature="voice")]
 extern crate sodiumoxide;
+#[cfg(feature="tokio-core")]
+extern crate tokio_core;
 #[cfg(feature="client")]
 extern crate typemap;
 #[cfg(feature="gateway")]

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -1,7 +1,7 @@
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt, WriteBytesExt};
 use opus::{
     Channels,
-    CodingMode,
+    Application as CodingMode,
     Decoder as OpusDecoder,
     Encoder as OpusEncoder,
     packet as opus_packet,


### PR DESCRIPTION
I've also switched to `Mutex` from `parking_lot` for `context` and `data` in `Client`, as a deadlock would occur using `Mutex` from the standard library under Windows 10 (maybe other versions too).

I'm not totally sure if the the voice stuff needs to be switched, so I have not done so.  I also haven't really tested this without the `framework` feature.  This code addresses #121.