### PR TITLE
Make CloseHandle derive Copy

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -56,7 +56,7 @@ use ::framework::Framework;
 
 static HANDLE_STILL: AtomicBool = ATOMIC_BOOL_INIT;
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct CloseHandle;
 
 impl CloseHandle {


### PR DESCRIPTION
This avoids the need to explicitly `.clone()`.