### PR TITLE
Added streaming option for set_game() and set_presence()

### DIFF
--- a/src/framework/mod.rs
+++ b/src/framework/mod.rs
@@ -608,7 +608,7 @@ impl BuiltinFramework {
     /// This requires that a check - if one exists - passes, prior to being
     /// called.
     ///
-    /// Note that once v0.2.0 lands, you will need to use the command builder
+    /// Prior to v0.2.0, you will need to use the command builder
     /// via the [`command`] method to set checks. This command will otherwise
     /// only be for simple commands.
     ///


### PR DESCRIPTION
Apparently, Discord made a "breaking" change with how the presence is being set. The type parameter (streaming or not streaming) is now required.
I have updated `set_game()` and `set_presence()` to fit these new changes.

There are now 2 additional parameters required, namely `streaming: bool` and `url: Option<&str>`.
Hopefully this little PR will help out.

PS: Yes, I am a Rust noob, so don't judge me.