### PR TITLE
Make args empty when no arguments are passed.

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -22,9 +22,15 @@ pub struct Args {
 
 impl Args {
     pub fn new(message: &str, delimiter: &str) -> Self {
+        let split = if message.trim().is_empty() {
+            Vec::new()
+        } else {
+            message.split(delimiter).map(|s| s.to_string()).collect()
+        };
+        
         Args {
             delimiter: delimiter.to_string(),
-            delimiter_split: message.split(delimiter).map(|s| s.to_string()).collect(),
+            delimiter_split: split,
         }
     }
     


### PR DESCRIPTION
Just doing the split will leave an empty string in the vector if message is empty. This will make an empty vector instead if the trimmed version of message is empty.