### PR TITLE
Fix presence updates

### DIFF
--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -909,6 +909,8 @@ impl Shard {
                 "status": status.name(),
                 "game": game.as_ref().map(|x| json!({
                     "name": x.name,
+                    "type": x.kind,
+                    "url": x.url,
                 })),
             },
         });


### PR DESCRIPTION
Due to the changes made, type and url are now required parameters. Without them the presence will not update.