### PR TITLE
Use cache when possible in UserId's get method

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -28,7 +28,7 @@ impl Args {
         } else {
             message.split(delimiter).map(|s| s.to_string()).collect()
         };
-        
+
         Args {
             delimiter: delimiter.to_string(),
             delimiter_split: split,

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -742,7 +742,16 @@ impl UserId {
     ///
     /// **Note**: The current user must be a bot user.
     #[inline]
-    pub fn get(&self) -> Result<User> { http::get_user(self.0) }
+    pub fn get(&self) -> Result<User> { 
+        #[cfg(feature = "cache")]
+        {
+            if let Some(user) = CACHE.read().unwrap().user(*self) {
+                return Ok(user.read().unwrap().clone());
+            }
+        }
+
+        http::get_user(self.0) 
+    }
 }
 
 impl From<CurrentUser> for UserId {

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -742,7 +742,7 @@ impl UserId {
     ///
     /// **Note**: The current user must be a bot user.
     #[inline]
-    pub fn get(&self) -> Result<User> { 
+    pub fn get(&self) -> Result<User> {
         #[cfg(feature = "cache")]
         {
             if let Some(user) = CACHE.read().unwrap().user(*self) {
@@ -750,7 +750,7 @@ impl UserId {
             }
         }
 
-        http::get_user(self.0) 
+        http::get_user(self.0)
     }
 }
 


### PR DESCRIPTION
I'm not sure if unwrapping is fine here, but I assumed since unwraps are used for the cache that it'd be fine for the lock as well. If this won't work, then I'll try to find another way to handle it.