### PR TITLE
Allow FromStr for User to use REST

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,8 @@
 //! [examples]: https://github.com/zeyla/serenity/tree/master/examples
 //! [gateway docs]: gateway/index.html
 #![doc(html_root_url = "https://docs.rs/serenity/*")]
-#![allow(doc_markdown, inline_always, unknown_lints)]
+#![allow(unknown_lints)]
+#![allow(doc_markdown, inline_always)]
 #![warn(enum_glob_use, if_not_else)]
 
 #[macro_use]

--- a/src/model/misc.rs
+++ b/src/model/misc.rs
@@ -61,7 +61,6 @@ impl Mentionable for User {
 #[cfg(all(feature = "cache", feature = "utils"))]
 #[derive(Debug)]
 pub enum UserParseError {
-    NotPresentInCache,
     InvalidUsername,
     Rest(Box<std::error::Error>),
 }
@@ -78,7 +77,6 @@ impl StdError for UserParseError {
         use self::UserParseError::*;
 
         match *self {
-            NotPresentInCache => "not present in cache",
             InvalidUsername => "invalid username",
             Rest(_) => "could not fetch",
         }


### PR DESCRIPTION
If a user is invisible or not in the cache, the current implementation will fail to get their information. This change will make a REST call if the user is not found in the cache.

Also fixed lint warnings.