### PR TITLE
Prevent malformed opus data from crashing the bot process

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -78,23 +78,25 @@ impl Context {
     pub fn edit_profile<F: FnOnce(EditProfile) -> EditProfile>(&self, f: F) -> Result<CurrentUser> {
         let mut map = Map::new();
 
-        feature_cache! {{
-                            let cache = CACHE.read().unwrap();
-        
-                            map.insert("username".to_owned(), Value::String(cache.user.name.clone()));
-        
-                            if let Some(email) = cache.user.email.as_ref() {
-                                map.insert("email".to_owned(), Value::String(email.clone()));
-                            }
-                        } else {
-                            let user = http::get_current_user()?;
-        
-                            map.insert("username".to_owned(), Value::String(user.name.clone()));
-        
-                            if let Some(email) = user.email.as_ref() {
-                                map.insert("email".to_owned(), Value::String(email.clone()));
-                            }
-                        }}
+        feature_cache! {
+            {
+                let cache = CACHE.read().unwrap();
+
+                map.insert("username".to_owned(), Value::String(cache.user.name.clone()));
+
+                if let Some(email) = cache.user.email.as_ref() {
+                    map.insert("email".to_owned(), Value::String(email.clone()));
+                }
+            } else {
+                let user = http::get_current_user()?;
+
+                map.insert("username".to_owned(), Value::String(user.name.clone()));
+
+                if let Some(email) = user.email.as_ref() {
+                    map.insert("email".to_owned(), Value::String(email.clone()));
+                }
+            }
+        }
 
         let edited = f(EditProfile(map)).0;
 

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -138,41 +138,43 @@ impl Shard {
         let session_id = None;
 
         let mut shard =
-            feature_voice! {{
-                                            let (tx, rx) = mpsc::channel();
-        
-                                            let user = http::get_current_user()?;
-        
-                                            Shard {
-                                                client,
-                                                current_presence,
-                                                heartbeat_instants,
-                                                heartbeat_interval,
-                                                last_heartbeat_acknowledged,
-                                                seq,
-                                                stage,
-                                                token,
-                                                session_id,
-                                                shard_info,
-                                                ws_url,
-                                                manager: VoiceManager::new(tx, user.id),
-                                                manager_rx: rx,
-                                            }
-                                        } else {
-                                            Shard {
-                                                client,
-                                                current_presence,
-                                                heartbeat_instants,
-                                                heartbeat_interval,
-                                                last_heartbeat_acknowledged,
-                                                seq,
-                                                stage,
-                                                token,
-                                                session_id,
-                                                shard_info,
-                                                ws_url,
-                                            }
-                                        }};
+            feature_voice! {
+                {
+                    let (tx, rx) = mpsc::channel();
+
+                    let user = http::get_current_user()?;
+
+                    Shard {
+                        client,
+                        current_presence,
+                        heartbeat_instants,
+                        heartbeat_interval,
+                        last_heartbeat_acknowledged,
+                        seq,
+                        stage,
+                        token,
+                        session_id,
+                        shard_info,
+                        ws_url,
+                        manager: VoiceManager::new(tx, user.id),
+                        manager_rx: rx,
+                    }
+                } else {
+                    Shard {
+                        client,
+                        current_presence,
+                        heartbeat_instants,
+                        heartbeat_interval,
+                        last_heartbeat_acknowledged,
+                        seq,
+                        stage,
+                        token,
+                        session_id,
+                        shard_info,
+                        ws_url,
+                    }
+                }
+            };
 
         shard.identify()?;
 

--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -46,31 +46,34 @@ impl Reaction {
     /// [Manage Messages]: permissions/constant.MANAGE_MESSAGES.html
     /// [permissions]: permissions
     pub fn delete(&self) -> Result<()> {
-        let user_id = feature_cache! {{
-                                            let user = if self.user_id == CACHE.read().unwrap().user.id {
-                                                None
-                                            } else {
-                                                Some(self.user_id.0)
-                                            };
-        
-                                            // If the reaction is one _not_ made by the current user, then ensure
-                                            // that the current user has permission* to delete the reaction.
-                                            //
-                                            // Normally, users can only delete their own reactions.
-                                            //
-                                            // * The `Manage Messages` permission.
-                                            if user.is_some() {
-                                                let req = permissions::MANAGE_MESSAGES;
-        
-                                                if !utils::user_has_perms(self.channel_id, req).unwrap_or(true) {
-                                                    return Err(Error::Model(ModelError::InvalidPermissions(req)));
-                                                }
-                                            }
-        
-                                            user
-                                        } else {
-                                            Some(self.user_id.0)
-                                        }};
+        let user_id =
+            feature_cache! {
+            {
+                let user = if self.user_id == CACHE.read().unwrap().user.id {
+                    None
+                } else {
+                    Some(self.user_id.0)
+                };
+
+                // If the reaction is one _not_ made by the current user, then ensure
+                // that the current user has permission* to delete the reaction.
+                //
+                // Normally, users can only delete their own reactions.
+                //
+                // * The `Manage Messages` permission.
+                if user.is_some() {
+                    let req = permissions::MANAGE_MESSAGES;
+
+                    if !utils::user_has_perms(self.channel_id, req).unwrap_or(true) {
+                        return Err(Error::Model(ModelError::InvalidPermissions(req)));
+                    }
+                }
+
+                user
+            } else {
+                Some(self.user_id.0)
+            }
+        };
 
         http::delete_reaction(self.channel_id.0, self.message_id.0, user_id, &self.emoji)
     }

--- a/src/model/user.rs
+++ b/src/model/user.rs
@@ -492,35 +492,38 @@ impl User {
             return Err(Error::Model(ModelError::MessagingBot));
         }
 
-        let private_channel_id = feature_cache! {{
-                                            let finding = {
-                                                let cache = CACHE.read().unwrap();
-        
-                                                let finding = cache.private_channels
-                                                    .values()
-                                                    .map(|ch| ch.read().unwrap())
-                                                    .find(|ch| ch.recipient.read().unwrap().id == self.id)
-                                                    .map(|ch| ch.id);
-        
-                                                finding
-                                            };
-        
-                                            if let Some(finding) = finding {
-                                                finding
-                                            } else {
-                                                let map = json!({
-                                                    "recipient_id": self.id.0,
-                                                });
-        
-                                                http::create_private_channel(&map)?.id
-                                            }
-                                        } else {
-                                            let map = json!({
-                                                "recipient_id": self.id.0,
-                                            });
-        
-                                            http::create_private_channel(&map)?.id
-                                        }};
+        let private_channel_id =
+            feature_cache! {
+            {
+                let finding = {
+                    let cache = CACHE.read().unwrap();
+
+                    let finding = cache.private_channels
+                        .values()
+                        .map(|ch| ch.read().unwrap())
+                        .find(|ch| ch.recipient.read().unwrap().id == self.id)
+                        .map(|ch| ch.id);
+
+                    finding
+                };
+
+                if let Some(finding) = finding {
+                    finding
+                } else {
+                    let map = json!({
+                        "recipient_id": self.id.0,
+                    });
+
+                    http::create_private_channel(&map)?.id
+                }
+            } else {
+                let map = json!({
+                    "recipient_id": self.id.0,
+                });
+
+                http::create_private_channel(&map)?.id
+            }
+        };
 
         private_channel_id.send_message(f)
     }

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -48,6 +48,11 @@ impl<R: Read + Send> AudioSource for InputSource<R> {
     fn read_opus_frame(&mut self) -> Option<Vec<u8>> {
         match self.reader.read_i16::<LittleEndian>() {
             Ok(size) => {
+                if size <= 0 {
+                    warn!("Invalid opus frame size: {}", size);
+                    return None;
+                }
+
                 let mut frame = Vec::with_capacity(size as usize);
 
                 {


### PR DESCRIPTION
I forgot to add this check before my previous PR. It won't be a common crash if you use proper tools, but passing a malformed data to `opus` could potentially cause an allocation failure which would stop the bot process. To prevent this, just make sure the size isn't negative or zero.

If you give it an invalid file now it won't crash, but it will still uncleanly kill the thread with an out-of-bounds slice index error. I don't know where it's coming from, but the bot stays in voice, continues to take commands, and generally functions so I believe it's not a massive problem. I might make a separate issue for it if I can't figure it out though.