### PR TITLE
Add num_args

### DIFF
--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -178,6 +178,14 @@ impl CreateCommand {
         self
     }
 
+    /// Exact number of arguments that should be passed.
+    pub fn num_args(mut self, num_args: i32) -> Self {
+        self.0.min_args = Some(num_args);
+        self.0.max_args = Some(num_args);
+
+        self
+    }
+
     /// Whether command can be used only privately or not.
     pub fn owners_only(mut self, owners_only: bool) -> Self {
         self.0.owners_only = owners_only;


### PR DESCRIPTION
Useful in instances where a command takes an exact amount of arguments. 

Avoids calling both min and max args:
```rust
command("cmd", |c| c
    .min_args(1)
    .max_args(1)
    // ...
```

And also avoids doing manual checks in commands:
```rust
command!(cmd(_ctx, msg, args) {
    if args.len() != 1 {
        // print message or just return
    }
    // ...
});
```