### PR TITLE
Commands can now be limited to certain roles

### DIFF
--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -57,6 +57,8 @@ pub struct Command {
     pub max_args: Option<i32>,
     /// Permissions required to use this command.
     pub required_permissions: Permissions,
+    /// Roles allowed to use this command.
+    pub allowed_roles: Vec<String>,
     /// Whether command should be displayed in help list or not, used by other commands.
     pub help_available: bool,
     /// Whether command can be used only privately or not.
@@ -86,6 +88,7 @@ impl Command {
             max_args: None,
             owners_only: false,
             required_permissions: Permissions::empty(),
+            allowed_roles: Vec::new(),
         }
     }
 }

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -207,6 +207,13 @@ impl CreateCommand {
 
         self
     }
+
+    /// Sets roles that are allowed to use the command.
+    pub fn allowed_roles(mut self, allowed_roles: Vec<&str>) -> Self {
+        self.0.allowed_roles = allowed_roles.iter().map(|x| x.to_string()).collect();
+
+        self
+    }
 }
 
 impl Default for Command {
@@ -226,6 +233,7 @@ impl Default for Command {
             guild_only: false,
             help_available: true,
             owners_only: false,
+            allowed_roles: Vec::new(),
         }
     }
 }

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -56,8 +56,9 @@ fn right_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
             .iter()
             .flat_map(|r| guild.role_by_name(&r))
             .any(|g| member.roles.contains(&g.id));
+    } else {
+        true
     }
-    true
 }
 
 /// Posts an embed showing each individual command group and its commands.
@@ -289,7 +290,6 @@ pub fn plain(_: &mut Context,
                                     }
                                 }
                             }
-                            println!("found");
                             found = Some((command_name, cmd));
                         },
                         CommandOrAlias::Alias(ref name) => {

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -52,10 +52,10 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
 
 fn right_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
     if cmd.allowed_roles.len() > 0 {
-        return cmd.allowed_roles
+        cmd.allowed_roles
             .iter()
             .flat_map(|r| guild.role_by_name(&r))
-            .any(|g| member.roles.contains(&g.id));
+            .any(|g| member.roles.contains(&g.id))
     } else {
         true
     }


### PR DESCRIPTION
Also, `help_commands::with_embeds` and `help_commands::plain` check if user has the right role to use them.

Both will be bypassed by a user with `permissions::ADMINISTRATOR` but not with being an owner. I'm not sure if the bot-owner should be able to do bypass, as that might enable security backdoors... someone uses your bot, you join their server and then the owner abuses admin-features and so on...

I called the field of `Command` `allowed_roles`, because having one of these roles gains permission to use it. If `Vec<String>` stays empty, no special role-checks will be done.