### PR TITLE
Fixed a "bug" where the admin-permission did not bypass `allowed_roles`.

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -51,7 +51,7 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
 }
 
 fn right_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
-    if cmd.allowed_roles.len() > 0 {
+    if !cmd.allowed_roles.is_empty() {
         cmd.allowed_roles
             .iter()
             .flat_map(|r| guild.role_by_name(&r))


### PR DESCRIPTION
I somehow forgot to add the check for admin-permissions when a command is triggered. Once the user has these rights, they will bypass the necessity of having a certain role.

Additionally changed `len() > 0` to `!is_empty()`.