### PR TITLE
Copy some methods from Command to Group

### DIFF
--- a/src/client/context.rs
+++ b/src/client/context.rs
@@ -47,7 +47,10 @@ pub struct Context {
 
 impl Context {
     /// Create a new Context to be passed to an event handler.
-    pub(crate) fn new(shard: Arc<Mutex<Shard>>, data: Arc<Mutex<ShareMap>>, handle: Handle) -> Context {
+    pub(crate) fn new(shard: Arc<Mutex<Shard>>,
+                      data: Arc<Mutex<ShareMap>>,
+                      handle: Handle)
+                      -> Context {
         Context {
             data,
             shard,

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -30,10 +30,17 @@ pub enum CommandType {
     WithCommands(Box<Help>),
 }
 
-#[derive(Default)]
 pub struct CommandGroup {
     pub prefix: Option<String>,
     pub commands: HashMap<String, CommandOrAlias>,
+    /// Some fields taken from Command
+    pub bucket: Option<String>,
+    pub required_permissions: Permissions,
+    pub allowed_roles: Vec<String>,
+    pub help_available: bool,
+    pub dm_only: bool,
+    pub guild_only: bool,
+    pub owners_only: bool,
 }
 
 /// Command struct used to store commands internally.


### PR DESCRIPTION
I added some of the fields from Command into CommandGroup, copied over some methods, and made it so when CreateGroup's command method is called, the CreateCommand that is passed has the default values set.

The only thing that is missing is `checks`, but I don't know how to handle copying that into group. It would be nice if someone else could add that later.