### PR TITLE
Use `request_client!` for attachment downloading

### DIFF
--- a/src/model/channel/attachment.rs
+++ b/src/model/channel/attachment.rs
@@ -106,7 +106,7 @@ impl Attachment {
     /// [`Error::Io`]: ../enum.Error.html#variant.Io
     /// [`Message`]: struct.Message.html
     pub fn download(&self) -> Result<Vec<u8>> {
-        let hyper = HyperClient::new();
+        let hyper = request_client!();
         let mut response = hyper.get(&self.url).send()?;
 
         let mut bytes = vec![];


### PR DESCRIPTION
Change attachment downloading to use the `request_client!` macro, which uses `hyper_native_tls`, which allows a https connection to be created.

Fixes bug where downloading attachments would fail due to non-https connection.