### PR TITLE
Replace Vec parameters by IntoIterator

### DIFF
--- a/src/builder/create_embed.rs
+++ b/src/builder/create_embed.rs
@@ -143,7 +143,7 @@ impl CreateEmbed {
     }
 
     /// Adds multiple fields at once.
-    pub fn fields(mut self, fields: Vec<CreateEmbedField>) -> Self {
+    pub fn fields<It: IntoIterator<Item=CreateEmbedField>>(mut self, fields: It) -> Self {
         let fields = fields
             .into_iter()
             .map(|m| Value::Object(m.0))

--- a/src/builder/create_message.rs
+++ b/src/builder/create_message.rs
@@ -74,7 +74,7 @@ impl CreateMessage {
     }
 
     /// Adds a list of reactions to create after the message's sent.
-    pub fn reactions<R: Into<ReactionType>>(mut self, reactions: Vec<R>) -> Self {
+    pub fn reactions<R: Into<ReactionType>, It: IntoIterator<Item=R>>(mut self, reactions: It) -> Self {
         self.1 = Some(reactions.into_iter().map(|r| r.into()).collect());
 
         CreateMessage(self.0, self.1)

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -9,7 +9,7 @@ use std::sync::RwLock;
 
 pub trait EventHandler {
     #[cfg(feature = "cache")]
-    fn on_cached<It: IntoIterator<Item=GuildId>>(&self, _: Context, _: It) {}
+    fn on_cached(&self, _: Context, _: Vec<GuildId>) {}
     fn on_channel_create(&self, _: Context, _: Arc<RwLock<GuildChannel>>) {}
     fn on_category_create(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
     fn on_category_delete(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
@@ -60,12 +60,12 @@ pub trait EventHandler {
     fn on_guild_update(&self, _: Context, _: PartialGuild) {}
     fn on_message(&self, _: Context, _: Message) {}
     fn on_message_delete(&self, _: Context, _: ChannelId, _: MessageId) {}
-    fn on_message_delete_bulk<It: IntoIterator<Item=MessageId>>(&self, _: Context, _: ChannelId, _: It) {}
+    fn on_message_delete_bulk(&self, _: Context, _: ChannelId, _: Vec<MessageId>) {}
     fn on_reaction_add(&self, _: Context, _: Reaction) {}
     fn on_reaction_remove(&self, _: Context, _: Reaction) {}
     fn on_reaction_remove_all(&self, _: Context, _: ChannelId, _: MessageId) {}
     fn on_message_update(&self, _: Context, _: MessageUpdateEvent) {}
-    fn on_presence_replace<It: IntoIterator<Item=Presence>>(&self, _: Context, _: It) {}
+    fn on_presence_replace(&self, _: Context, _: Vec<Presence>) {}
     fn on_presence_update(&self, _: Context, _: PresenceUpdateEvent) {}
     fn on_ready(&self, _: Context, _: Ready) {}
     fn on_resume(&self, _: Context, _: ResumedEvent) {}

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -9,7 +9,7 @@ use std::sync::RwLock;
 
 pub trait EventHandler {
     #[cfg(feature = "cache")]
-    fn on_cached(&self, _: Context, _: Vec<GuildId>) {}
+    fn on_cached<It: IntoIterator<Item=GuildId>>(&self, _: Context, _: It) {}
     fn on_channel_create(&self, _: Context, _: Arc<RwLock<GuildChannel>>) {}
     fn on_category_create(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
     fn on_category_delete(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
@@ -60,12 +60,12 @@ pub trait EventHandler {
     fn on_guild_update(&self, _: Context, _: PartialGuild) {}
     fn on_message(&self, _: Context, _: Message) {}
     fn on_message_delete(&self, _: Context, _: ChannelId, _: MessageId) {}
-    fn on_message_delete_bulk(&self, _: Context, _: ChannelId, _: Vec<MessageId>) {}
+    fn on_message_delete_bulk<It: IntoIterator<Item=MessageId>>(&self, _: Context, _: ChannelId, _: It) {}
     fn on_reaction_add(&self, _: Context, _: Reaction) {}
     fn on_reaction_remove(&self, _: Context, _: Reaction) {}
     fn on_reaction_remove_all(&self, _: Context, _: ChannelId, _: MessageId) {}
     fn on_message_update(&self, _: Context, _: MessageUpdateEvent) {}
-    fn on_presence_replace(&self, _: Context, _: Vec<Presence>) {}
+    fn on_presence_replace<It: IntoIterator<Item=Presence>>(&self, _: Context, _: It) {}
     fn on_presence_update(&self, _: Context, _: PresenceUpdateEvent) {}
     fn on_ready(&self, _: Context, _: Ready) {}
     fn on_resume(&self, _: Context, _: ResumedEvent) {}

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -4,6 +4,7 @@ use super::command::PrefixCheck;
 use client::Context;
 use http;
 use model::{GuildId, Message, UserId};
+use std::string::ToString;
 
 /// The configuration to use for a [`Framework`] associated with a [`Client`]
 /// instance.
@@ -352,8 +353,8 @@ impl Configuration {
     /// client.with_framework(StandardFramework::new().configure(|c| c
     ///     .prefixes(vec!["!", ">", "+"])));
     /// ```
-    pub fn prefixes(mut self, prefixes: Vec<&str>) -> Self {
-        self.prefixes = prefixes.iter().map(|x| x.to_string()).collect();
+    pub fn prefixes<T: ToString, It: IntoIterator<Item=T>>(mut self, prefixes: It) -> Self {
+        self.prefixes = prefixes.into_iter().map(|x| x.to_string()).collect();
 
         self
     }
@@ -401,7 +402,7 @@ impl Configuration {
     /// client.with_framework(StandardFramework::new().configure(|c| c
     ///     .delimiters(vec![", ", " "])));
     /// ```
-    pub fn delimiters(mut self, delimiters: Vec<&str>) -> Self {
+    pub fn delimiters<T: ::std::string::ToString, It: ::std::iter::IntoIterator<Item=T>>(mut self, delimiters: It) -> Self {
         self.delimiters.clear();
         self.delimiters
             .extend(delimiters.into_iter().map(|s| s.to_string()));

--- a/src/framework/standard/configuration.rs
+++ b/src/framework/standard/configuration.rs
@@ -4,7 +4,6 @@ use super::command::PrefixCheck;
 use client::Context;
 use http;
 use model::{GuildId, Message, UserId};
-use std::string::ToString;
 
 /// The configuration to use for a [`Framework`] associated with a [`Client`]
 /// instance.
@@ -402,7 +401,7 @@ impl Configuration {
     /// client.with_framework(StandardFramework::new().configure(|c| c
     ///     .delimiters(vec![", ", " "])));
     /// ```
-    pub fn delimiters<T: ::std::string::ToString, It: ::std::iter::IntoIterator<Item=T>>(mut self, delimiters: It) -> Self {
+    pub fn delimiters<T: ToString, It: IntoIterator<Item=T>>(mut self, delimiters: It) -> Self {
         self.delimiters.clear();
         self.delimiters
             .extend(delimiters.into_iter().map(|s| s.to_string()));

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -2,6 +2,7 @@ pub use super::{Args, Command, CommandGroup, CommandType, CommandError};
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::string::ToString;
 use client::Context;
 use model::{Message, Permissions};
 
@@ -9,10 +10,10 @@ pub struct CreateCommand(pub Command);
 
 impl CreateCommand {
     /// Adds multiple aliases.
-    pub fn batch_known_as(mut self, names: Vec<&str>) -> Self {
+    pub fn batch_known_as<T: ToString, It: IntoIterator<Item=T>>(mut self, names: It) -> Self {
         self.0
             .aliases
-            .extend(names.into_iter().map(|n| n.to_owned()));
+            .extend(names.into_iter().map(|n| n.to_string()));
 
         self
     }
@@ -212,8 +213,8 @@ impl CreateCommand {
     }
 
     /// Sets roles that are allowed to use the command.
-    pub fn allowed_roles(mut self, allowed_roles: Vec<&str>) -> Self {
-        self.0.allowed_roles = allowed_roles.iter().map(|x| x.to_string()).collect();
+    pub fn allowed_roles<T: ToString, It: IntoIterator<Item=T>>(mut self, allowed_roles: It) -> Self {
+        self.0.allowed_roles = allowed_roles.into_iter().map(|x| x.to_string()).collect();
 
         self
     }

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -2,7 +2,6 @@ pub use super::{Args, Command, CommandGroup, CommandType, CommandError};
 
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::string::ToString;
 use client::Context;
 use model::{Message, Permissions};
 

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use client::Context;
 use model::{Message, Permissions};
 use std::collections::HashMap;
-use std::string::ToString;
 
 /// Used to create command groups
 ///

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 use client::Context;
 use model::{Message, Permissions};
 use std::collections::HashMap;
+use std::string::ToString;
 
 /// Used to create command groups
 ///
@@ -139,8 +140,8 @@ impl CreateGroup {
     }
 
     /// Sets roles that are allowed to use the command.
-    pub fn allowed_roles(mut self, allowed_roles: Vec<&str>) -> Self {
-        self.0.allowed_roles = allowed_roles.iter().map(|x| x.to_string()).collect();
+    pub fn allowed_roles<T: ToString, It: IntoIterator<Item=T>>(mut self, allowed_roles: It) -> Self {
+        self.0.allowed_roles = allowed_roles.into_iter().map(|x| x.to_string()).collect();
 
         self
     }

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1611,7 +1611,7 @@ pub fn remove_group_recipient(group_id: u64, user_id: u64) -> Result<()> {
 /// if the file is too large to send.
 ///
 /// [`HttpError::InvalidRequest`]: enum.HttpError.html#variant.InvalidRequest
-pub fn send_files<'a, T>(channel_id: u64, files: Vec<T>, map: JsonMap) -> Result<Message>
+pub fn send_files<'a, T, It: ::std::iter::IntoIterator<Item=T>>(channel_id: u64, files: It, map: JsonMap) -> Result<Message>
     where T: Into<AttachmentType<'a>> {
     let uri = format!(api!("/channels/{}/messages"), channel_id);
     let url = match Url::parse(&uri) {
@@ -1632,7 +1632,7 @@ pub fn send_files<'a, T>(channel_id: u64, files: Vec<T>, map: JsonMap) -> Result
     let mut request = Multipart::from_request(request)?;
     let mut file_num = "0".to_owned();
 
-    for file in files {
+    for file in files.into_iter() {
         match file.into() {
             AttachmentType::Bytes((mut bytes, filename)) => {
                 request

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1611,7 +1611,7 @@ pub fn remove_group_recipient(group_id: u64, user_id: u64) -> Result<()> {
 /// if the file is too large to send.
 ///
 /// [`HttpError::InvalidRequest`]: enum.HttpError.html#variant.InvalidRequest
-pub fn send_files<'a, T, It: ::std::iter::IntoIterator<Item=T>>(channel_id: u64, files: It, map: JsonMap) -> Result<Message>
+pub fn send_files<'a, T, It: IntoIterator<Item=T>>(channel_id: u64, files: It, map: JsonMap) -> Result<Message>
     where T: Into<AttachmentType<'a>> {
     let uri = format!(api!("/channels/{}/messages"), channel_id);
     let url = match Url::parse(&uri) {

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -439,7 +439,7 @@ impl ChannelId {
     /// [`GuildChannel`]: struct.GuildChannel.html
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
-    pub fn send_files<'a, F, T, It: ::std::iter::IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         let mut map = f(CreateMessage::default()).0;
 

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -439,7 +439,7 @@ impl ChannelId {
     /// [`GuildChannel`]: struct.GuildChannel.html
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
-    pub fn send_files<'a, F, T>(&self, files: Vec<T>, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: ::std::iter::IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         let mut map = f(CreateMessage::default()).0;
 

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -295,7 +295,7 @@ impl Group {
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
     #[inline]
-    pub fn send_files<'a, F, T>(&self, files: Vec<T>, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: ::std::iter::IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         self.channel_id.send_files(files, f)
     }

--- a/src/model/channel/group.rs
+++ b/src/model/channel/group.rs
@@ -295,7 +295,7 @@ impl Group {
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
     #[inline]
-    pub fn send_files<'a, F, T, It: ::std::iter::IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         self.channel_id.send_files(files, f)
     }

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -578,7 +578,7 @@ impl GuildChannel {
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
     #[inline]
-    pub fn send_files<'a, F, T>(&self, files: Vec<T>, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         self.id.send_files(files, f)
     }

--- a/src/model/channel/mod.rs
+++ b/src/model/channel/mod.rs
@@ -287,7 +287,7 @@ impl Channel {
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
     #[cfg(feature = "model")]
     #[inline]
-    pub fn send_files<'a, F, T>(&self, files: Vec<T>, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         self.id().send_files(files, f)
     }

--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -240,7 +240,7 @@ impl PrivateChannel {
     /// [Attach Files]: permissions/constant.ATTACH_FILES.html
     /// [Send Messages]: permissions/constant.SEND_MESSAGES.html
     #[inline]
-    pub fn send_files<'a, F, T>(&self, files: Vec<T>, f: F) -> Result<Message>
+    pub fn send_files<'a, F, T, It: IntoIterator<Item=T>>(&self, files: It, f: F) -> Result<Message>
         where F: FnOnce(CreateMessage) -> CreateMessage, T: Into<AttachmentType<'a>> {
         self.id.send_files(files, f)
     }


### PR DESCRIPTION
Part of #174 

Maybe I should use `where` clauses instead of `fn foo<It: IntoIterator>(_: It)`. What do you think?