### PR TITLE
Help-commands filtering and Member-prefix-search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/zeyla/serenity.git"
-version = "0.4.0"
+version = "0.4.1"
 
 [dependencies]
 bitflags = "^1.0"

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -22,7 +22,7 @@ use std::default::Default;
 use std::sync::Arc;
 use client::Context;
 use super::Framework;
-use model::{ChannelId, GuildId, Message, UserId};
+use model::{ChannelId, GuildId, Guild, Member, Message, UserId};
 use model::permissions::Permissions;
 use internal::RwLockExt;
 
@@ -514,12 +514,7 @@ impl StandardFramework {
                         if let Some(member) = guild.members.get(&message.author.id) {
                             if let Ok(permissions) = member.permissions() {
                                 if !permissions.administrator() {
-                                    let right_role = command
-                                        .allowed_roles
-                                        .iter()
-                                        .flat_map(|r| guild.role_by_name(r))
-                                        .any(|g| member.roles.contains(&g.id));
-                                    if !right_role {
+                                    if !has_correct_roles(&command, &guild, &member) {
                                         return Some(DispatchError::LackingRole);
                                     }
                                 }
@@ -947,7 +942,7 @@ impl Framework for StandardFramework {
 }
 
 #[cfg(feature = "cache")]
-pub(crate) fn has_correct_permissions(command: &Arc<Command>, message: &Message) -> bool {
+pub(crate) fn has_correct_permissions(command: &Command, message: &Message) -> bool {
     if !command.required_permissions.is_empty() {
         if let Some(guild) = message.guild() {
             let perms = guild
@@ -958,4 +953,12 @@ pub(crate) fn has_correct_permissions(command: &Arc<Command>, message: &Message)
     }
 
     true
+}
+
+#[cfg(feature = "cache")]
+pub(crate) fn has_correct_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
+    cmd.allowed_roles
+            .iter()
+            .flat_map(|r| guild.role_by_name(r))
+            .any(|g| member.roles.contains(&g.id))
 }

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -749,7 +749,7 @@ impl Guild {
     /// - "Zey", "ZEYla", "zeY mei"
     /// 
     /// [`Member`]: struct.Member.html
-    pub fn members_starting_with(&self, prefix: &str, case_sensitive: bool) -> Vec<&Member> {
+    pub fn members_starting_with(&self, prefix: &str) -> Vec<&Member> {
         self.members
             .values()
             .filter(|member|

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -741,6 +741,24 @@ impl Guild {
             })
     }
 
+    /// Retrieves all [`Member`] that start with a given `String`.
+    ///
+    /// If the prefix is "zey", following results are possible:
+    /// - "zey", "zeyla", "zey mei"
+    /// But the following are not because case-sensitivity:
+    /// - "Zey", "ZEYla", "zeY mei"
+    /// 
+    /// [`Member`]: struct.Member.html
+    pub fn members_starting_with(&self, prefix: &str, case_sensitive: bool) -> Vec<&Member> {
+        self.members
+            .values()
+            .filter(|member|
+                member.user.read().unwrap().name.starts_with(prefix)
+                || member.nick.as_ref()
+                    .map_or(false, |nick|
+                        nick.starts_with(prefix))).collect()
+    }
+
     /// Moves a member to a specific voice channel.
     ///
     /// Requires the [Move Members] permission.


### PR DESCRIPTION
Moved the check whether a user is member of a command's required roles from `help_command` to the same place as `has_correct_permissions`.

Added search for `Member` starting with an in common prefix.

Renamed the role-check to `has_correct_roles` to align with `has_correct_permissions`.

Changed Serenity's version from `v0.4.0` to `v0.4.1`.