### PR TITLE
Do not default the command argument delimiter to " " if none of the provided delimiters are found

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -60,7 +60,12 @@ pub struct Args {
 }
 
 impl Args {
-    pub fn new(message: &str, delimiter: &str) -> Self {
+    pub fn new(message: &str, possible_delimiters: Vec<String>) -> Self {
+        let delimiter = possible_delimiters
+            .iter()
+            .find(|&d| message.contains(d))
+            .map_or(possible_delimiters[0].as_str(), |s| s.as_str());
+
         let split = if message.trim().is_empty() {
             Vec::new()
         } else {

--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -18,7 +18,7 @@ impl<E: StdError> From<E> for Error<E> {
     fn from(e: E) -> Self {
         Error::Parse(e)
     }
-} 
+}
 
 impl<E: StdError> StdError for Error<E> {
     fn description(&self) -> &str {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -901,13 +901,7 @@ impl Framework for StandardFramework {
                             let mut content = message.content[position..].trim();
                             content = content[command_length..].trim();
 
-                            let delimiter = self.configuration
-                                .delimiters
-                                .iter()
-                                .find(|&d| content.contains(d))
-                                .map_or(" ", |s| s.as_str());
-
-                            Args::new(&content, delimiter)
+                            Args::new(&content, self.configuration.delimiters.clone())
                         };
 
                         if let Some(error) = self.should_fail(


### PR DESCRIPTION
By no longer forcing a last-resort argument delimiter of " ", we now allow a command configured with `min_args(2)`, and a bot configured with `delimiters(vec![", "])` to have `!command first argument` fail, instead of it being run with `["first", "argument"]`.

If a bot wishes to retain the previous behavior of falling back to `" "` for the argument parsing if no other delimiters are found, then `" "` will need to be added to the end of the delimiters list (Eg: `delimiters(vec![", ", " "])`).

This also moves the delimiter detection into Args itself in anticipation of future refactoring of the argument parsing.

This  should address #181.