### PR TITLE
Find `Member` via substrings, allow case-insensitivity on `members_containing` and `members_starting_with`

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -829,7 +829,7 @@ impl Guild {
             Some(everyone) => everyone,
             None => {
                 error!(
-                    "(?°?°)?? ??? @everyone role ({}) missing in '{}'",
+                    "(╯°□°）╯︵ ┻━┻ @everyone role ({}) missing in '{}'",
                     self.id,
                     self.name
                 );
@@ -851,7 +851,7 @@ impl Guild {
                 permissions |= role.permissions;
             } else {
                 warn!(
-                    "(?°?°)?? ??? {} on {} has non-existent role {:?}",
+                    "(╯°□°）╯︵ ┻━┻ {} on {} has non-existent role {:?}",
                     member.user.read().unwrap().id,
                     self.id,
                     role
@@ -905,7 +905,7 @@ impl Guild {
             }
         } else {
             warn!(
-                "(?°?°)?? ??? Guild {} does not contain channel {}",
+                "(╯°□°）╯︵ ┻━┻ Guild {} does not contain channel {}",
                 self.id,
                 channel_id
             );
@@ -1380,7 +1380,7 @@ impl GuildStatus {
 enum_number!(
     #[doc="The level to set as criteria prior to a user being able to send
     messages in a [`Guild`].
-    
+
     [`Guild`]: struct.Guild.html"]
     VerificationLevel {
         /// Does not require any verification.


### PR DESCRIPTION
`Member` can be found by substrings in their display-name or nick.
Both `members_starting_with` and `members_containing` allow to search case-insensitive now.