### PR TITLE
Variety of methods to search for `Member` with a substring/prefix in user- or nickname.

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -783,28 +783,28 @@ impl Guild {
                     let name_a = match a.nick {
                         Some(ref nick) => {
                             if contains_case_insensitive(&a.user.read().unwrap().name[..], &prefix) {
-                                a.user.read().unwrap().name.to_owned()
+                                a.user.read().unwrap().name.clone()
                             } else {
-                                nick.to_owned()
+                                nick.clone()
                             }
                         },
-                        None => a.user.read().unwrap().name.to_owned(),
+                        None => a.user.read().unwrap().name.clone(),
                     };
 
                     let name_b = match b.nick {
                         Some(ref nick) => {
                             if contains_case_insensitive(&b.user.read().unwrap().name[..], &prefix) {
-                                b.user.read().unwrap().name.to_owned()
+                                b.user.read().unwrap().name.clone()
                             } else {
-                                nick.to_owned()
+                                nick.clone()
                             }
                         },
-                        None => b.user.read().unwrap().name.to_owned(),
+                        None => b.user.read().unwrap().name.clone(),
                     };
 
                     closest_to_origin(&prefix, &name_a[..], &name_b[..])
                 });
-            return members;
+            members
         } else {
             members
         }
@@ -859,28 +859,28 @@ impl Guild {
                     let name_a = match a.nick {
                         Some(ref nick) => {
                             if contains_case_insensitive(&a.user.read().unwrap().name[..], &substring) {
-                                a.user.read().unwrap().name.to_owned()
+                                a.user.read().unwrap().name.clone()
                             } else {
-                                nick.to_owned()
+                                nick.clone()
                             }
                         },
-                        None => a.user.read().unwrap().name.to_owned(),
+                        None => a.user.read().unwrap().name.clone(),
                     };
 
                     let name_b = match b.nick {
                         Some(ref nick) => {
                             if contains_case_insensitive(&b.user.read().unwrap().name[..], &substring) {
-                                b.user.read().unwrap().name.to_owned()
+                                b.user.read().unwrap().name.clone()
                             } else {
-                                nick.to_owned()
+                                nick.clone()
                             }
                         },
-                        None => b.user.read().unwrap().name.to_owned(),
+                        None => b.user.read().unwrap().name.clone(),
                     };
 
                     closest_to_origin(&substring, &name_a[..], &name_b[..])
                 });
-            return members;
+            members
         } else {
             members
         }
@@ -920,7 +920,7 @@ impl Guild {
                     let name_b = &b.user.read().unwrap().name;
                     closest_to_origin(&substring, &name_a[..], &name_b[..])
                 });
-            return members;
+            members
         } else {
             members
         }
@@ -964,21 +964,21 @@ impl Guild {
                 .sort_by(|a, b| {
                     let name_a = match a.nick {
                         Some(ref nick) => {
-                            nick.to_owned()
+                            nick.clone()
                         },
-                        None => a.user.read().unwrap().name.to_owned(),
+                        None => a.user.read().unwrap().name.clone(),
                     };
 
                     let name_b = match b.nick {
                         Some(ref nick) => {
-                                nick.to_owned()
+                                nick.clone()
                             },
-                        None => b.user.read().unwrap().name.to_owned(),
+                        None => b.user.read().unwrap().name.clone(),
                     };
 
                     closest_to_origin(&substring, &name_a[..], &name_b[..])
                 });
-            return members;
+            members
         } else {
             members
         }


### PR DESCRIPTION
`members_containing` finds `Member` with a given substring in either their user- or nickname.
`members_nick_containing` finds `Member` with a given substring in their nickname.
`members_username_containing` finds `Member` with a given substring in their username.
`members_starting_with` got updated and supports sorting the result now.

Additionally, all of these use `closest_to_origin()` in order to compare two `str&` against a `str&` representing the `origin` and informs whether the first `str&` is closer or further from the `origin`.