### PR TITLE
Set help related functions public.

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -53,7 +53,7 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
 
 /// Checks whether a user is member of required roles 
 /// and given the required permissions.
-fn has_all_requirements(cmd: &Command, guild: &Guild, member: &Member, msg: &Message) -> bool {
+pub fn has_all_requirements(cmd: &Command, guild: &Guild, member: &Member, msg: &Message) -> bool {
     if cmd.allowed_roles.is_empty() {
         has_correct_permissions(cmd, msg)
     } else {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -942,7 +942,7 @@ impl Framework for StandardFramework {
 }
 
 #[cfg(feature = "cache")]
-pub(crate) fn has_correct_permissions(command: &Command, message: &Message) -> bool {
+pub fn has_correct_permissions(command: &Command, message: &Message) -> bool {
     if !command.required_permissions.is_empty() {
         if let Some(guild) = message.guild() {
             let perms = guild
@@ -956,7 +956,7 @@ pub(crate) fn has_correct_permissions(command: &Command, message: &Message) -> b
 }
 
 #[cfg(feature = "cache")]
-pub(crate) fn has_correct_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
+pub fn has_correct_roles(cmd: &Command, guild: &Guild, member: &Member) -> bool {
     cmd.allowed_roles
             .iter()
             .flat_map(|r| guild.role_by_name(r))


### PR DESCRIPTION
`has_correct_permissions`, `has_correct_roles` and `has_all_requirements` has been set public.

This gives the user the possibility to create their own help-functions.