### PR TITLE
Help-features display `Aliases` and list information for `Aliases`.

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -29,7 +29,7 @@ use std::fmt::Write;
 use super::command::InternalCommand;
 use super::{Args, Command, CommandGroup, CommandOrAlias, CommandError};
 use client::Context;
-use model::{ChannelId, Guild, Member, Message};
+use model::{ChannelId, Message};
 use utils::Colour;
 use framework::standard::{has_correct_roles, has_correct_permissions};
 
@@ -51,14 +51,25 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
     result
 }
 
-/// Checks whether a user is member of required roles
+/// Checks whether a user is member of required roles 
 /// and given the required permissions.
-pub fn has_all_requirements(cmd: &Command, guild: &Guild, member: &Member, msg: &Message) -> bool {
-    if cmd.allowed_roles.is_empty() {
-        has_correct_permissions(cmd, msg)
-    } else {
-        has_correct_roles(cmd, guild, member) && has_correct_permissions(cmd, msg)
+pub fn has_all_requirements(cmd: &Command, msg: &Message) -> bool {
+    if let Some(guild) = msg.guild() {
+        let guild = guild.read().unwrap();
+
+        if let Some(member) = guild.members.get(&msg.author.id) {
+
+            if let Ok(permissions) = member.permissions() {
+
+                if cmd.allowed_roles.is_empty() {
+                    return permissions.administrator() || has_correct_permissions(&cmd, &msg);
+                } else {
+                    return permissions.administrator() || (has_correct_roles(&cmd, &guild, &member) && has_correct_permissions(cmd, msg));
+                }
+            }
+        }
     }
+    false
 }
 
 /// Posts an embed showing each individual command group and its commands.
@@ -100,25 +111,31 @@ pub fn with_embeds(_: &mut Context,
                 if name == with_prefix || name == *command_name {
                     match *command {
                         CommandOrAlias::Command(ref cmd) => {
-                            if !cmd.allowed_roles.is_empty() {
-                                if let Some(guild) = msg.guild() {
-                                    let guild = guild.read().unwrap();
-                                    if let Some(member) = guild.members.get(&msg.author.id) {
-                                        if let Ok(permissions) = member.permissions() {
-                                            if !permissions.administrator() &&
-                                               !has_all_requirements(cmd, &guild, member, msg) {
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
+                            if has_all_requirements(&cmd, &msg) {
+                                found = Some((command_name, cmd));
                             }
-                            found = Some((command_name, cmd));
+                            else {
+                                break;
+                            }                 
                         },
                         CommandOrAlias::Alias(ref name) => {
-                            error_embed(&msg.channel_id, &format!("Did you mean \"{}\"?", name));
+                            let actual_command = &group.commands.get(name).unwrap();
 
-                            return Ok(());
+                            match *actual_command {
+                                &CommandOrAlias::Command(ref cmd) => {
+                                    if has_all_requirements(&cmd, &msg) {
+                                        found = Some((name, cmd));
+                                    }
+                                    else {
+                                        break;
+                                    }
+                                },
+
+                                &CommandOrAlias::Alias(ref name) => {
+                                    let _ = msg.channel_id.say(&format!("Did you mean {:?}?", name));
+                                    return Ok(());
+                                },
+                            }
                         },
                     }
                 }
@@ -134,6 +151,7 @@ pub fn with_embeds(_: &mut Context,
                 let _ = msg.channel_id.send_message(|m| {
                     m.embed(|e| {
                         let mut embed = e.colour(Colour::rosewater()).title(command_name);
+
                         if let Some(ref desc) = command.desc {
                             embed = embed.description(desc);
                         }
@@ -154,6 +172,11 @@ pub fn with_embeds(_: &mut Context,
 
                         if group_name != "Ungrouped" {
                             embed = embed.field(|f| f.name("Group").value(&group_name));
+                        }
+
+                        if !command.aliases.is_empty() {
+                            let aliases = command.aliases.join(", ");
+                            embed = embed.field(|f| f.name("Aliases").value(&aliases));
                         }
 
                         let available = if command.dm_only {
@@ -208,21 +231,14 @@ pub fn with_embeds(_: &mut Context,
                     let cmd = &commands[name];
 
                     if cmd.help_available {
-                        if let Some(guild) = msg.guild() {
-                            let guild = guild.read().unwrap();
-                            if let Some(member) = guild.members.get(&msg.author.id) {
-                                if let Ok(permissions) = member.permissions() {
-                                    if cmd.help_available &&
-                                       (has_all_requirements(cmd, &guild, member, msg) ||
-                                        permissions.administrator()) {
-                                        let _ = write!(desc, "`{}`\n", name);
-                                        has_commands = true;
-                                    }
-                                }
-                            }
+
+                        if cmd.help_available && has_all_requirements(&cmd, &msg) {
+                            let _ = write!(desc, "`{}`\n", name);
+                            has_commands = true;
                         }
                     }
                 }
+
                 if has_commands {
                     e = e.field(|f| f.name(group_name).value(&desc));
                 }
@@ -252,7 +268,6 @@ pub fn with_embeds(_: &mut Context,
 /// client.with_framework(StandardFramework::new()
 ///     .command("help", |c| c.exec_help(help_commands::plain)));
 /// ```
-#[cfg_attr(feature = "cargo-clippy", allow(cyclomatic_complexity))]
 pub fn plain(_: &mut Context,
              msg: &Message,
              groups: HashMap<String, Arc<CommandGroup>>,
@@ -274,24 +289,31 @@ pub fn plain(_: &mut Context,
                 if name == with_prefix || name == *command_name {
                     match *command {
                         CommandOrAlias::Command(ref cmd) => {
-                            if !cmd.allowed_roles.is_empty() {
-                                if let Some(guild) = msg.guild() {
-                                    let guild = guild.read().unwrap();
-                                    if let Some(member) = guild.members.get(&msg.author.id) {
-                                        if let Ok(permissions) = member.permissions() {
-                                            if !permissions.administrator() &&
-                                               !has_all_requirements(cmd, &guild, member, msg) {
-                                                break;
-                                            }
-                                        }
-                                    }
-                                }
+                            if has_all_requirements(&cmd, &msg) {
+                                found = Some((command_name, cmd));
                             }
-                            found = Some((command_name, cmd));
+                            else {
+                                break;
+                            }
                         },
                         CommandOrAlias::Alias(ref name) => {
-                            let _ = msg.channel_id.say(&format!("Did you mean {:?}?", name));
-                            return Ok(());
+                            let actual_command = &group.commands.get(name).unwrap();
+
+                            match *actual_command {
+                                &CommandOrAlias::Command(ref cmd) => {
+                                    if has_all_requirements(&cmd, &msg) {
+                                        found = Some((name, cmd));
+                                    }
+                                    else {
+                                        break;
+                                    }
+                                },
+
+                                &CommandOrAlias::Alias(ref name) => {
+                                    let _ = msg.channel_id.say(&format!("Did you mean {:?}?", name));
+                                    return Ok(());
+                                },
+                            }
                         },
                     }
                 }
@@ -304,6 +326,11 @@ pub fn plain(_: &mut Context,
                 }
 
                 let mut result = format!("**{}**\n", command_name);
+
+                if !command.aliases.is_empty() {
+                    let aliases = command.aliases.join("`, `");
+                    let _ = write!(result, "**Aliases:** `{}`\n", aliases);
+                }
 
                 if let Some(ref desc) = command.desc {
                     let _ = write!(result, "**Description:** {}\n", desc);
@@ -362,16 +389,9 @@ pub fn plain(_: &mut Context,
 
         for name in command_names {
             let cmd = &commands[name];
-            if let Some(guild) = msg.guild() {
-                let guild = guild.read().unwrap();
-                if let Some(member) = guild.members.get(&msg.author.id) {
-                    if let Ok(permissions) = member.permissions() {
-                        if cmd.help_available &&
-                           (permissions.administrator() || has_all_requirements(cmd, &guild, member, msg)) {
-                            let _ = write!(group_help, "`{}` ", name);
-                        }
-                    }
-                }
+
+            if cmd.help_available && has_all_requirements(&cmd, &msg) {
+                let _ = write!(group_help, "`{}` ", name);
             }
         }
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -119,10 +119,10 @@ pub fn with_embeds(_: &mut Context,
                             }                 
                         },
                         CommandOrAlias::Alias(ref name) => {
-                            let actual_command = &group.commands.get(name).unwrap();
+                            let actual_command = group.commands.get(name).unwrap();
 
                             match *actual_command {
-                                &CommandOrAlias::Command(ref cmd) => {
+                                CommandOrAlias::Command(ref cmd) => {
                                     if has_all_requirements(&cmd, &msg) {
                                         found = Some((name, cmd));
                                     }
@@ -131,7 +131,7 @@ pub fn with_embeds(_: &mut Context,
                                     }
                                 },
 
-                                &CommandOrAlias::Alias(ref name) => {
+                                CommandOrAlias::Alias(ref name) => {
                                     let _ = msg.channel_id.say(&format!("Did you mean {:?}?", name));
                                     return Ok(());
                                 },
@@ -297,10 +297,10 @@ pub fn plain(_: &mut Context,
                             }
                         },
                         CommandOrAlias::Alias(ref name) => {
-                            let actual_command = &group.commands.get(name).unwrap();
+                            let actual_command = group.commands.get(name).unwrap();
 
                             match *actual_command {
-                                &CommandOrAlias::Command(ref cmd) => {
+                                CommandOrAlias::Command(ref cmd) => {
                                     if has_all_requirements(&cmd, &msg) {
                                         found = Some((name, cmd));
                                     }
@@ -309,7 +309,7 @@ pub fn plain(_: &mut Context,
                                     }
                                 },
 
-                                &CommandOrAlias::Alias(ref name) => {
+                                CommandOrAlias::Alias(ref name) => {
                                     let _ = msg.channel_id.say(&format!("Did you mean {:?}?", name));
                                     return Ok(());
                                 },


### PR DESCRIPTION
Old help-features gave the real name of a command if the user sent an alias (but did not actually provide any information about it), now the help-features will search for the real command via an alias and use that result instead.

Additionally, Help-features will display a command's aliases as well.

Last but not least, moved duplicated code into `has_all_requirements`.