### PR TITLE
Take into account the Date Header when ratelimiting

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,4 +174,4 @@ Voice+youtube-dl:
 [library:discord.js]: https://github.com/hydrabolt/discord.js
 [library:discord.py]: https://github.com/Rapptz/discord.py
 [library:discord-rs]: https://github.com/SpaceManiac/discord-rs
-[logo]: https://raw.githubusercontent.com/zeyla/serenity/master/logo.png
+[logo]: https://zey.moe/assets/serenity_logo.png

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -38,7 +38,7 @@ use hyper::net::HttpsConnector;
 use hyper::{header, Error as HyperError, Result as HyperResult, Url};
 use hyper_native_tls::NativeTlsClient;
 use multipart::client::Multipart;
-use self::ratelimiting::Route;
+use self::ratelimiting::{RATELIMITER, Route};
 use serde_json;
 use std::collections::BTreeMap;
 use std::default::Default;
@@ -1782,7 +1782,7 @@ pub fn unpin_message(channel_id: u64, message_id: u64) -> Result<()> {
 
 fn request<'a, F>(route: Route, f: F) -> Result<HyperResponse>
     where F: Fn() -> RequestBuilder<'a> {
-    let response = ratelimiting::RateLimiter::perform(route, || {
+    let response = RATELIMITER.lock().unwrap().perform(route, || {
         f().header(header::Authorization(TOKEN.lock().unwrap().clone()))
             .header(header::ContentType::json())
     })?;

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1782,7 +1782,7 @@ pub fn unpin_message(channel_id: u64, message_id: u64) -> Result<()> {
 
 fn request<'a, F>(route: Route, f: F) -> Result<HyperResponse>
     where F: Fn() -> RequestBuilder<'a> {
-    let response = ratelimiting::perform(route, || {
+    let response = ratelimiting::RateLimiter::perform(route, || {
         f().header(header::Authorization(TOKEN.lock().unwrap().clone()))
             .header(header::ContentType::json())
     })?;

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -89,8 +89,8 @@ lazy_static! {
     ///
     /// [`RateLimit`]: struct.RateLimit.html
     /// [`Route`]: enum.Route.html
-    pub static ref ROUTES: Arc<Mutex<HashMap<Route, Arc<Mutex<RateLimit>>>>> = {
-        Arc::new(Mutex::new(HashMap::default()))
+    pub static ref RATELIMITER: Arc<Mutex<RateLimiter>> = {
+        Arc::new(Mutex::new(RateLimiter::default()))
     };
 }
 
@@ -347,73 +347,79 @@ pub enum Route {
     None,
 }
 
-pub(crate) fn perform<'a, F>(route: Route, f: F) -> Result<Response>
-    where F: Fn() -> RequestBuilder<'a> {
-    loop {
-        // This will block if another thread already has the global
-        // unlocked already (due to receiving an x-ratelimit-global).
-        let _ = GLOBAL.lock().expect("global route lock poisoned");
+#[derive(Debug, Default)]
+pub struct RateLimiter {
+    routes: HashMap<Route, Arc<Mutex<RateLimit>>>,
+    time_offset: i64,
+}
 
-        // Perform pre-checking here:
-        //
-        // - get the route's relevant rate
-        // - sleep if that route's already rate-limited until the end of the
-        //   'reset' time;
-        // - get the global rate;
-        // - sleep if there is 0 remaining
-        // - then, perform the request
-        let bucket = Arc::clone(ROUTES
-            .lock()
-            .expect("routes poisoned")
-            .entry(route)
-            .or_insert_with(|| {
-                Arc::new(Mutex::new(RateLimit {
-                    limit: i64::MAX,
-                    remaining: i64::MAX,
-                    reset: i64::MAX,
-                }))
-            }));
+impl RateLimiter {
+    pub(crate) fn perform<'a, F>(&mut self, route: Route, f: F) -> Result<Response>
+        where F: Fn() -> RequestBuilder<'a> {
+        loop {
+            // This will block if another thread already has the global
+            // unlocked already (due to receiving an x-ratelimit-global).
+            let _ = GLOBAL.lock().expect("global route lock poisoned");
 
-        let mut lock = bucket.lock().unwrap();
-        lock.pre_hook(&route);
+            // Perform pre-checking here:
+            //
+            // - get the route's relevant rate
+            // - sleep if that route's already rate-limited until the end of the
+            //   'reset' time;
+            // - get the global rate;
+            // - sleep if there is 0 remaining
+            // - then, perform the request
+            let bucket = Arc::clone(self.routes
+                .entry(route)
+                .or_insert_with(|| {
+                    Arc::new(Mutex::new(RateLimit {
+                        limit: i64::MAX,
+                        remaining: i64::MAX,
+                        reset: i64::MAX,
+                    }))
+                }));
 
-        let response = super::retry(&f)?;
+            let mut lock = bucket.lock().unwrap();
+            lock.pre_hook(&route);
 
-        // Check if the request got ratelimited by checking for status 429,
-        // and if so, sleep for the value of the header 'retry-after' -
-        // which is in milliseconds - and then `continue` to try again
-        //
-        // If it didn't ratelimit, subtract one from the RateLimit's
-        // 'remaining'
-        //
-        // Update the 'reset' with the value of the 'x-ratelimit-reset'
-        // header
-        //
-        // It _may_ be possible for the limit to be raised at any time,
-        // so check if it did from the value of the 'x-ratelimit-limit'
-        // header. If the limit was 5 and is now 7, add 2 to the 'remaining'
-        if route == Route::None {
-            return Ok(response);
-        } else {
-            let redo = if response.headers.get_raw("x-ratelimit-global").is_some() {
-                let _ = GLOBAL.lock().expect("global route lock poisoned");
+            let response = super::retry(&f)?;
 
-                Ok(
-                    if let Some(retry_after) = parse_header(&response.headers, "retry-after")? {
-                        debug!("Ratelimited on route {:?} for {:?}ms", route, retry_after);
-                        thread::sleep(Duration::from_millis(retry_after as u64));
-
-                        true
-                    } else {
-                        false
-                    },
-                )
-            } else {
-                lock.post_hook(&response, &route)
-            };
-
-            if !redo.unwrap_or(true) {
+            // Check if the request got ratelimited by checking for status 429,
+            // and if so, sleep for the value of the header 'retry-after' -
+            // which is in milliseconds - and then `continue` to try again
+            //
+            // If it didn't ratelimit, subtract one from the RateLimit's
+            // 'remaining'
+            //
+            // Update the 'reset' with the value of the 'x-ratelimit-reset'
+            // header
+            //
+            // It _may_ be possible for the limit to be raised at any time,
+            // so check if it did from the value of the 'x-ratelimit-limit'
+            // header. If the limit was 5 and is now 7, add 2 to the 'remaining'
+            if route == Route::None {
                 return Ok(response);
+            } else {
+                let redo = if response.headers.get_raw("x-ratelimit-global").is_some() {
+                    let _ = GLOBAL.lock().expect("global route lock poisoned");
+
+                    Ok(
+                        if let Some(retry_after) = parse_header(&response.headers, "retry-after")? {
+                            debug!("Ratelimited on route {:?} for {:?}ms", route, retry_after);
+                            thread::sleep(Duration::from_millis(retry_after as u64));
+
+                            true
+                        } else {
+                            false
+                        },
+                    )
+                } else {
+                    lock.post_hook(&response, &route)
+                };
+
+                if !redo.unwrap_or(true) {
+                    return Ok(response);
+                }
             }
         }
     }

--- a/src/http/ratelimiting.rs
+++ b/src/http/ratelimiting.rs
@@ -341,7 +341,7 @@ pub struct RateLimiter {
     /// ```rust,no_run
     /// use serenity::http::ratelimiting::{RATELIMITER, Route};
     ///
-    /// let routes = RATELIMITER.lock().unwrap().routes;
+    /// let routes = &RATELIMITER.lock().unwrap().routes;
     ///
     /// if let Some(route) = routes.get(&Route::ChannelsId(7)) {
     ///     println!("Reset time at: {}", route.lock().unwrap().reset);


### PR DESCRIPTION
This makes the internal ratelimiter take into account the date header to calculate an offset from the date header provided in the response from discord. A fair bit of the ratelimting code had to be rewritten + re-arranged to accommodate this change.


This addresses issue https://github.com/zeyla/serenity/issues/84