### PR TITLE
Emojis `HashMap` will be updated, Serenity will retry connecting, cleaned up code

### DIFF
--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -113,8 +113,7 @@ pub fn with_embeds(_: &mut Context,
                         CommandOrAlias::Command(ref cmd) => {
                             if has_all_requirements(cmd, msg) {
                                 found = Some((command_name, cmd));
-                            }
-                            else {
+                            } else {
                                 break;
                             }
                         },
@@ -125,8 +124,7 @@ pub fn with_embeds(_: &mut Context,
                                 CommandOrAlias::Command(ref cmd) => {
                                     if has_all_requirements(cmd, msg) {
                                         found = Some((name, cmd));
-                                    }
-                                    else {
+                                    } else {
                                         break;
                                     }
                                 },

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -127,7 +127,7 @@ impl Shard {
                token: Arc<Mutex<String>>,
                shard_info: [u64; 2])
                -> Result<Shard> {
-        let client = connect(&*ws_url.lock().unwrap())?;
+        let client = connecting(&*ws_url.lock().unwrap());
 
         let current_presence = (None, OnlineStatus::Online, false);
         let heartbeat_instants = (None, None);
@@ -1045,49 +1045,21 @@ fn build_gateway_url(base: &str) -> Result<Url> {
         .map_err(|why| {
             warn!("Error building gateway URL with base `{}`: {:?}", base, why);
 
-<<<<<<< HEAD
             Error::Gateway(GatewayError::BuildingUrl)
         })
-=======
+}
+
 /// Tries to connect and upon failure, retries.
-fn connecting() -> WsClient {
-    let waiting_time = 120;
+fn connecting(uri: &str) -> WsClient {
+    let waiting_time = 30;
 
     loop {
-        match connect("") {
+        match connect(&uri) {
             Ok(client) => return client,
-            Err(_) => {
-                warn!("Connecting failed, will retry in {} seconds.", waiting_time);
+            Err(why) => {
+                warn!("Connecting failed: {:?}\n Will retry in {} seconds.", why, waiting_time);
                 thread::sleep(StdDuration::from_secs(waiting_time));
             },
         };
     }
-}
-
-impl Default for Shard {
-    fn default() -> Self {
-        #[cfg(feature = "voice")]
-        let (tx, rx) = mpsc::channel();
-        #[cfg(feature = "voice")]
-        let user = http::get_current_user().unwrap();
-
-        Shard {
-            client: connecting(),
-            current_presence: (None, OnlineStatus::Online, false),
-            heartbeat_instants: (None, None),
-            heartbeat_interval: None,
-            last_heartbeat_acknowledged: true,
-            seq: 0,
-            stage: ConnectionStage::Handshake,
-            token: Arc::new(Mutex::new(String::new())),
-            session_id: None,
-            shard_info: [0; 2],
-            ws_url: Arc::new(Mutex::new(String::new())),
-            #[cfg(feature = "voice")]
-            manager: VoiceManager::new(tx, user.id),
-            #[cfg(feature = "voice")]
-            manager_rx: rx,
-        }
-    }
->>>>>>> If a guild's emojis are being altered, Serenity will straight up use the new `HashMap` instead of just extending.
 }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use std::net::Shutdown;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration as StdDuration, Instant};
+use std::thread;
 use super::{ConnectionStage, GatewayError};
 use websocket::client::Url;
 use websocket::message::{CloseData, OwnedMessage};
@@ -1044,6 +1045,47 @@ fn build_gateway_url(base: &str) -> Result<Url> {
         .map_err(|why| {
             warn!("Error building gateway URL with base `{}`: {:?}", base, why);
 
+<<<<<<< HEAD
             Error::Gateway(GatewayError::BuildingUrl)
         })
+=======
+/// Tries to connect and upon failure, retries.
+fn connecting() -> WsClient {
+    loop {
+        match connect(&String::new()) {
+            Ok(client) => return client,
+            Err(_) => {
+                warn!("Connecting failed, will retry in 30 seconds.");
+                thread::sleep(StdDuration::from_secs(30));
+            },
+        };
+    }
+}
+
+impl Default for Shard {
+    fn default() -> Self {
+        #[cfg(feature = "voice")]
+        let (tx, rx) = mpsc::channel();
+        #[cfg(feature = "voice")]
+        let user = http::get_current_user().unwrap();
+
+        Shard {
+            client: connecting(),
+            current_presence: (None, OnlineStatus::Online, false),
+            heartbeat_instants: (None, None),
+            heartbeat_interval: None,
+            last_heartbeat_acknowledged: true,
+            seq: 0,
+            stage: ConnectionStage::Handshake,
+            token: Arc::new(Mutex::new(String::new())),
+            session_id: None,
+            shard_info: [0; 2],
+            ws_url: Arc::new(Mutex::new(String::new())),
+            #[cfg(feature = "voice")]
+            manager: VoiceManager::new(tx, user.id),
+            #[cfg(feature = "voice")]
+            manager_rx: rx,
+        }
+    }
+>>>>>>> If a guild's emojis are being altered, Serenity will straight up use the new `HashMap` instead of just extending.
 }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -1051,12 +1051,14 @@ fn build_gateway_url(base: &str) -> Result<Url> {
 =======
 /// Tries to connect and upon failure, retries.
 fn connecting() -> WsClient {
+    let waiting_time = 120;
+
     loop {
         match connect("") {
             Ok(client) => return client,
             Err(_) => {
-                warn!("Connecting failed, will retry in 30 seconds.");
-                thread::sleep(StdDuration::from_secs(30));
+                warn!("Connecting failed, will retry in {} seconds.", waiting_time);
+                thread::sleep(StdDuration::from_secs(waiting_time));
             },
         };
     }

--- a/src/gateway/shard.rs
+++ b/src/gateway/shard.rs
@@ -1052,7 +1052,7 @@ fn build_gateway_url(base: &str) -> Result<Url> {
 /// Tries to connect and upon failure, retries.
 fn connecting() -> WsClient {
     loop {
-        match connect(&String::new()) {
+        match connect("") {
             Ok(client) => return client,
             Err(_) => {
                 warn!("Connecting failed, will retry in 30 seconds.");

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -404,7 +404,9 @@ impl CacheUpdate for GuildEmojisUpdateEvent {
 
     fn update(&mut self, cache: &mut Cache) -> Option<()> {
         cache.guilds.get_mut(&self.guild_id).map(|guild| {
-            guild.with_mut(|g| g.emojis = self.emojis.clone())
+            guild.with_mut(|g| {
+                g.emojis.clone_from(&self.emojis)
+            });
         });
 
         None

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -404,7 +404,7 @@ impl CacheUpdate for GuildEmojisUpdateEvent {
 
     fn update(&mut self, cache: &mut Cache) -> Option<()> {
         cache.guilds.get_mut(&self.guild_id).map(|guild| {
-            guild.with_mut(|g| g.emojis.extend(self.emojis.clone()))
+            guild.with_mut(|g| g.emojis = self.emojis.clone())
         });
 
         None


### PR DESCRIPTION
When a guild updates its Emojis, Serenity will `clone()` the new `HashMap` instead of just `extend()`.

If `connect()` returns an `Err()`, it will retry connecting.

Cleaned up `help_command.rs`.