### PR TITLE
Accept anything Display for PrivateChannel::say

### DIFF
--- a/src/model/channel/private_channel.rs
+++ b/src/model/channel/private_channel.rs
@@ -219,7 +219,7 @@ impl PrivateChannel {
     /// [`ChannelId`]: ../model/struct.ChannelId.html
     /// [`ModelError::MessageTooLong`]: enum.ModelError.html#variant.MessageTooLong
     #[inline]
-    pub fn say(&self, content: &str) -> Result<Message> { self.id.say(content) }
+    pub fn say<D: ::std::fmt::Display>(&self, content: D) -> Result<Message> { self.id.say(content) }
 
     /// Sends (a) file(s) along with optional message contents.
     ///


### PR DESCRIPTION
It just calls `self.id.say` which already accepts `Display`, and `&str` is `Display`.