### PR TITLE
Fixed strange behaviour for when the prefix has spaces

### DIFF
--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -208,12 +208,9 @@ fn find_end_of_prefix_with_whitespace(content: &str, position: usize) -> Option<
 
     let slice = unsafe { content.slice_unchecked(position, content_len) }.as_bytes();
     for i in 0..slice.len() {
-        // 0x20 is ASCII for space
         match slice[i] {
-            0x09 => {} // \t
-            0x0a => {} // \n
-            0x0d => {} // \r
-            0x20 => {} // [space]
+            // \t \n \r [space]
+            0x09 | 0x0a | 0x0d | 0x20 => {}
             _ => return if i == 0 { None } else { Some(position + i) }
         }
     }

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -203,20 +203,19 @@ fn find_mention_end(content: &str, conf: &Configuration) -> Option<usize> {
 
 // Finds the end of the first continuous block of whitespace after the prefix
 fn find_end_of_prefix_with_whitespace(content: &str, position: usize) -> Option<usize> {
-    let mut ws_split = content.split_whitespace();
-    if let Some(cmd) = ws_split.nth(1) {
-        if let Some(index_of_cmd) = content.find(cmd) {
-            if index_of_cmd > position && index_of_cmd <= content.len() {
-                let slice = unsafe { content.slice_unchecked(position, index_of_cmd) }.as_bytes();
-                for byte in slice.iter() {
-                    // 0x20 is ASCII for space
-                    if *byte != 0x20u8 {
-                        return None;
-                    }
-                }
-                return Some(index_of_cmd);
-            }
+    let content_len = content.len();
+    if position >= content_len { return None; }
+
+    let slice = unsafe { content.slice_unchecked(position, content_len) }.as_bytes();
+    for i in 0..slice.len() {
+        // 0x20 is ASCII for space
+        match slice[i] {
+            0x09 => {} // \t
+            0x0a => {} // \n
+            0x0d => {} // \r
+            0x20 => {} // [space]
+            _ => return if i == 0 { None } else { Some(position + i) }
         }
     }
-    None
+    Some(content.len())
 }


### PR DESCRIPTION
The last time I was in this section of code, I splitted the string by *whitespaces* then took the second element, ignoring whether the prefix has whitespaces in it or not. I re-implemented the function to prevent strange behaviours for prefixes with whitespaces, and also added cases for non-space whitespaces.