### PR TITLE
ReactionType conversion traits

### DIFF
--- a/src/model/channel/reaction.rs
+++ b/src/model/channel/reaction.rs
@@ -255,6 +255,24 @@ impl From<Emoji> for ReactionType {
     }
 }
 
+impl From<EmojiId> for ReactionType {
+    fn from(emoji_id: EmojiId) -> ReactionType {
+        ReactionType::Custom {
+            id: emoji_id,
+            name: None
+        }
+    }
+}
+
+impl From<EmojiIdentifier> for ReactionType {
+    fn from(emoji_id: EmojiIdentifier) -> ReactionType {
+        ReactionType::Custom {
+            id: emoji_id.id,
+            name: Some(emoji_id.name)
+        }
+    }
+}
+
 impl From<String> for ReactionType {
     fn from(unicode: String) -> ReactionType { ReactionType::Unicode(unicode) }
 }


### PR DESCRIPTION
This PR implements `From<EmojiId>` and `From<EmojiIdentifier>` for `ReactionType`. I'm not exactly sure what the `name` field on `ReactionType::Custom` does, but it's set to `None` when converting from `EmojiId` for now.