### PR TITLE
standard framework: Document that application owners bypass checks

### DIFF
--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -26,6 +26,8 @@ impl CreateCommand {
     /// Adds a "check" to a command, which checks whether or not the command's
     /// function should be called.
     ///
+    /// These checks are bypassed for commands sent by the application owner.
+    ///
     /// # Examples
     ///
     /// Ensure that the user who created a message, calling a "ping" command,


### PR DESCRIPTION
This is intended according to @zeyla but wasn't documented so I got confused when my command checks were being ignored.