### PR TITLE
Add `help()` to `CreateGroup`.

### DIFF
--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -2,6 +2,7 @@ use client::Context;
 use model::{Message, Permissions};
 use std::collections::HashMap;
 use std::fmt;
+use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
 use super::{Args, Configuration};
 
@@ -9,8 +10,18 @@ pub type Check = Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> bool
                      + Send
                      + Sync
                      + 'static;
-pub type Help = fn(&mut Context, &Message, HashMap<String, Arc<CommandGroup>>, Args)
+
+pub type HelpFunction = fn(&mut Context, &Message, HashMap<String, Arc<CommandGroup>>, Args)
                    -> Result<(), Error>;
+
+pub struct Help(pub HelpFunction);
+
+impl Debug for Help {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "fn()")
+    }
+}
+
 pub type BeforeHook = Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
 pub type AfterHook = Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
 pub(crate) type InternalCommand = Arc<Command>;
@@ -53,6 +64,7 @@ pub struct CommandGroup {
     pub dm_only: bool,
     pub guild_only: bool,
     pub owners_only: bool,
+    pub help: Option<Arc<Help>>,
 }
 
 impl Default for CommandGroup {
@@ -67,6 +79,7 @@ impl Default for CommandGroup {
             help_available: true,
             owners_only: false,
             allowed_roles: Vec::new(),
+            help: None,
         }
     }
 }

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -1,6 +1,6 @@
 pub use super::command::{Command, CommandGroup, CommandOptions, Error as CommandError};
 pub(crate) use super::command::CommandOrAlias;
-pub(crate) use super::command::A;
+pub(crate) use super::command::{A, Help, HelpFunction};
 pub use super::create_command::{CreateCommand, FnOrCommand};
 pub use super::Args;
 
@@ -74,23 +74,30 @@ impl CreateGroup {
             f: fn(&mut Context, &Message, Args) -> Result<(), CommandError>) -> Self {
         self._cmd(name, A(f))
     }
-    
+
     /// Like [`on`], but accepts a `Command` directly.
     ///
     /// [`on`]: #method.on
     pub fn cmd<C: Command + 'static>(self, name: &str, c: C) -> Self {
         self._cmd(name, c)
-    }    
-    
+    }
+
     fn _cmd<C: Command + 'static>(mut self, name: &str, c: C) -> Self {
         let cmd = Arc::new(c);
-        
+
         self.0
             .commands
             .insert(name.to_string(), CommandOrAlias::Command(cmd));
 
         self
-    }    
+    }
+
+    /// Sets what code should be execute when a user requests for `(prefix)help`.
+    pub fn help(mut self, f: HelpFunction) -> Self {
+        self.0.help = Some(Arc::new(Help(f)));
+
+        self
+    }
 
     /// If prefix is set, it will be required before all command names.
     /// For example, if bot prefix is "~" and group prefix is "image"

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -10,7 +10,7 @@ mod args;
 
 pub use self::args::{Args, Iter, FromStrZc, Error as ArgError};
 pub(crate) use self::buckets::{Bucket, Ratelimit};
-pub(crate) use self::command::{A, Help};
+pub(crate) use self::command::{A, Help, HelpFunction};
 pub use self::command::{Command, CommandGroup, CommandOptions, Error as CommandError};
 pub use self::command::CommandOrAlias;
 pub use self::configuration::Configuration;
@@ -78,7 +78,7 @@ macro_rules! command {
                       _: &$crate::model::Message,
                       _: $crate::framework::standard::Args)
                       -> ::std::result::Result<(), $crate::framework::standard::CommandError> {
-                
+
                 $b
 
                 Ok(())
@@ -95,7 +95,7 @@ macro_rules! command {
                       $m: &$crate::model::Message,
                       _: $crate::framework::standard::Args)
                       -> ::std::result::Result<(), $crate::framework::standard::CommandError> {
-                
+
                 $b
 
                 Ok(())
@@ -112,7 +112,7 @@ macro_rules! command {
                       $m: &$crate::model::Message,
                       mut $a: $crate::framework::standard::Args)
                       -> ::std::result::Result<(), $crate::framework::standard::CommandError> {
-                
+
                 $b
 
                 Ok(())
@@ -126,7 +126,7 @@ macro_rules! command {
 pub enum DispatchError {
     /// When a custom function check has failed.
     //
-    // TODO: Bring back `Arc<Command>` as `CommandOptions` here somehow? 
+    // TODO: Bring back `Arc<Command>` as `CommandOptions` here somehow?
     CheckFailed,
     /// When the requested command is disabled in bot configuration.
     CommandDisabled(String),
@@ -638,7 +638,7 @@ impl StandardFramework {
     }
 
     /// Same as [`on`], but accepts a [`Command`] directly.
-    /// 
+    ///
     /// [`on`]: #method.on
     /// [`Command`]: trait.Command.html
     pub fn cmd<C: Command + 'static>(self, name: &str, c: C) -> Self {
@@ -712,9 +712,9 @@ impl StandardFramework {
     }
 
     /// Sets what code should be execute when a user requests for `(prefix)help`.
-    pub fn help(mut self, f: Help) -> Self {
-        self.help = Some(Arc::new(f));
-        
+    pub fn help(mut self, f: HelpFunction) -> Self {
+        self.help = Some(Arc::new(Help(f)));
+
         self
     }
 
@@ -960,7 +960,7 @@ impl Framework for StandardFramework {
                     let after = self.after.clone();
 
                     // This is a special case.
-                    if to_check == "help" {                        
+                    if to_check == "help" {
                         let help = self.help.clone();
                         if let Some(help) = help {
                             let groups = self.groups.clone();
@@ -971,7 +971,7 @@ impl Framework for StandardFramework {
                                     }
                                 }
 
-                                let result = (help)(&mut context, &message, groups, args);
+                                let result = (help.0)(&mut context, &message, groups, args);
 
                                 if let Some(after) = after {
                                     (after)(&mut context, &message, &built, result);


### PR DESCRIPTION
This PR adds the possibility to use `help()` on `group()` in the framework-configuration.

Changed `type Help` to `type HelpFunction` on a `newtype` `struct Help`, in order to implement the `debug`-`trait`.