### PR TITLE
Convert from try_opt macro to ?

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -193,7 +193,7 @@ impl Args {
         let mut vec = Vec::with_capacity(i as usize);
 
         for _ in 0..i {
-            vec.push(try_opt!(self.delimiter_split.shift()));
+            vec.push(self.delimiter_split.shift()?);
         }
 
         Some(vec)

--- a/src/internal/macros.rs
+++ b/src/internal/macros.rs
@@ -181,11 +181,3 @@ macro_rules! enum_number {
         }
     }
 }
-
-#[allow(unused_macros)]
-macro_rules! try_opt {
-    ($x:expr) => (match $x {
-        Some(v) => v,
-        None => return None,
-    });
-}

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -159,7 +159,7 @@ impl Member {
     #[cfg(all(feature = "cache", feature = "utils"))]
     pub fn colour(&self) -> Option<Colour> {
         let cache = CACHE.read();
-        let guild = try_opt!(cache.guilds.get(&self.guild_id)).read();
+        let guild = cache.guilds.get(&self.guild_id)?.read();
 
         let mut roles = self.roles
             .iter()


### PR DESCRIPTION
Now that `?` is stable on `Option` replace the macro that mimicked it. 