### PR TITLE
Fix syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ serenity = "0.4"
 
 and to the top of your `main.rs`:
 
-```rs
+```rust,ignore
 #[macro_use] extern crate serenity;
 ```
 


### PR DESCRIPTION
Before:
![before SS](https://user-images.githubusercontent.com/6709544/33799604-570498de-dd2f-11e7-92ee-afbda8e2d35f.png)

After: 
![after SS](https://user-images.githubusercontent.com/6709544/33799601-4d3159e6-dd2f-11e7-839f-0d71532f6c43.png)
