### PR TITLE
Fix Guild::member_named

### DIFF
--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -725,11 +725,13 @@ impl Guild {
     ///
     /// [`Member`]: struct.Member.html
     pub fn member_named(&self, name: &str) -> Option<&Member> {
-        let (name, discrim) = if let Some(pos) = name.find('#') {
-            let split = name.split_at(pos);
+        let (name, discrim) = if let Some(pos) = name.rfind('#') {
+            let split = name.split_at(pos+1);
+            
+            let split2 = (split.0.get(0..split.0.len()-1).unwrap() , split.1);
 
-            match split.1.parse::<u16>() {
-                Ok(discrim_int) => (split.0, Some(discrim_int)),
+            match split2.1.parse::<u16>() {
+                Ok(discrim_int) => (split2.0, Some(discrim_int)),
                 Err(_) => (name, None),
             }
         } else {


### PR DESCRIPTION
Use rfind, in case there's more '#' in username than just the discriminator

Split at `pos+1` instead of `pos` and remove the trailing '#' in the split.0 (Name)