### PR TITLE
Fix args' `parse()`.

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -79,15 +79,10 @@ fn parse<T: FromStr>(s: &mut String, delimiter: &str) -> Result<T, T::Err>
     where T::Err: StdError {
     let mut pos = s.find(delimiter).unwrap_or_else(|| s.len());
 
-
     let res = (&s[..pos]).parse::<T>().map_err(Error::Parse);
-    // First find out whether the delimiter is 2 chars or longer, 
-    // if so add those extras to the position.
-    // Otherwise just add `1` for 1 char delimiters.
-    if delimiter.len() > 1 {
+
+    if pos < s.len() {
         pos += delimiter.len();
-    } else if pos < s.len() {
-        pos += 1;
     }
 
     s.drain(..pos);
@@ -214,7 +209,7 @@ impl Args {
     pub fn full(&self) -> &str { &self.message }
 
     /// The amount of args.
-    /// 
+    ///
     /// # Examples
     ///
     /// ```rust

--- a/tests/test_args.rs
+++ b/tests/test_args.rs
@@ -1,0 +1,50 @@
+extern crate serenity;
+
+use serenity::framework::standard::Args;
+
+#[test]
+fn single_i32_with_2_bytes_long_delimiter() {
+    let mut args = Args::new("1, 2", &[", ".to_string()]);
+
+    assert_eq!(args.single::<i32>().unwrap(), 1);
+    assert_eq!(args.single::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn single_i32_with_1_byte_long_delimiter_i32() {
+    let mut args = Args::new("1,2", &[",".to_string()]);
+
+    assert_eq!(args.single::<i32>().unwrap(), 1);
+    assert_eq!(args.single::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn single_i32_with_wrong_char_after_first_arg() {
+    let mut args = Args::new("1, 2", &[",".to_string()]);
+
+    assert_eq!(args.single::<i32>().unwrap(), 1);
+    assert!(args.single::<i32>().is_err());
+}
+
+#[test]
+fn single_i32_with_one_character_being_3_bytes_long() {
+    let mut args = Args::new("1★2", &["★".to_string()]);
+
+    assert_eq!(args.single::<i32>().unwrap(), 1);
+    assert_eq!(args.single::<i32>().unwrap(), 2);
+}
+
+#[test]
+fn single_i32_with_untrimmed_whitespaces() {
+    let mut args = Args::new(" 1, 2 ", &[",".to_string()]);
+
+    assert!(args.single::<i32>().is_err());
+}
+
+#[test]
+fn single_i32_n() {
+    let args = Args::new("1,2", &[",".to_string()]);
+
+    assert_eq!(args.single_n::<i32>().unwrap(), 1);
+    assert_eq!(args.single_n::<i32>().unwrap(), 1);
+}


### PR DESCRIPTION
This will fix the current misbehaviour on delimiters that a larger than one byte.