### PR TITLE
Fix `multiple_quoted` behaviour

### DIFF
--- a/src/framework/standard/args.rs
+++ b/src/framework/standard/args.rs
@@ -64,7 +64,6 @@ fn parse_quotes<T: FromStr>(s: &mut String, delimiters: &[String]) -> Result<T, 
 
         if s.starts_with('"') {
             let res = (&s[1..pos]).parse::<T>().map_err(Error::Parse);
-
             pos += '"'.len_utf8();
 
             for delimiter in delimiters {


### PR DESCRIPTION
The rework in #239 did not fallback to `single_quoted` when `multiple_quoted` was unable to progress, which is being fixed with this PR.