### PR TITLE
Fix `has_all_requirements`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "ISC"
 name = "serenity"
 readme = "README.md"
 repository = "https://github.com/zeyla/serenity.git"
-version = "0.4.5"
+version = "0.4.7"
 
 [dependencies]
 bitflags = "^1.0"

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ serenity = "0.4"
 
 and to the top of your `main.rs`:
 
-```rs
+```rust,ignore
 #[macro_use] extern crate serenity;
 ```
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -69,7 +69,7 @@ pub fn has_all_requirements(cmd: &Command, msg: &Message) -> bool {
             }
         }
     }
-    false
+    !cmd.guild_only && cmd.dm_only
 }
 
 /// Posts an embed showing each individual command group and its commands.

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -69,7 +69,7 @@ pub fn has_all_requirements(cmd: &Command, msg: &Message) -> bool {
             }
         }
     }
-    !cmd.guild_only && cmd.dm_only
+    !cmd.guild_only
 }
 
 /// Posts an embed showing each individual command group and its commands.


### PR DESCRIPTION
This is supposed to be a fix for serenity's current help-commands on `v0.4.6`.

Bug: Help-command-features used in a DM-channel caused no help-commands to be displayed at all, due to `has_all_requirements` returning _false_ if the current channel is no guild
Solution: If `has_all_requirements` cannot find a guild, it will test whether the command is `dm_only` and not `guild_only`.

@Roughsketch shall test it before it gets merged! : )
  