### PR TITLE
Fix missing `correct roles`-check in help-commands

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1071,10 +1071,14 @@ pub fn has_correct_permissions(command: &Arc<CommandOptions>, message: &Message)
 
 #[cfg(feature = "cache")]
 pub fn has_correct_roles(cmd: &Arc<CommandOptions>, guild: &Guild, member: &Member) -> bool {
-    cmd.allowed_roles
+    if cmd.allowed_roles.is_empty() {
+        true
+    } else {
+        cmd.allowed_roles
             .iter()
             .flat_map(|r| guild.role_by_name(r))
             .any(|g| member.roles.contains(&g.id))
+    }
 }
 
 /// Describes the behaviour the help-command shall execute once it encounters


### PR DESCRIPTION
This PR adds checks to `help_commands.rs` to consider a user's roles, which was not considered at all.
It also updates the `has_correct_roles`-function to return true on empty vectors.