### PR TITLE
Added package.metadata.docs.rs at Cargo.toml to enable voice feature docs generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,6 @@ standard_framework = ["framework", "vec_shift"]
 utils = ["base64"]
 voice = ["byteorder", "gateway", "opus", "sodiumoxide"]
 websocket = ["evzht9h3nznqzwl"]
+
+[package.metadata.docs.rs]
+features = ["default", "voice"]


### PR DESCRIPTION
According to this code it should work: https://github.com/onur/docs.rs/blob/13da7b2cd11fd6ea954c1d0145490586411700a4/src/docbuilder/metadata.rs#L19