### PR TITLE
Trim after splitting at the mention-end.

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -970,7 +970,8 @@ impl Framework for StandardFramework {
                     };
 
                     let mut args = {
-                        let content = content.chars().skip(position + built.chars().count()).collect::<String>();
+                        let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
+                            .skip(built.chars().count()).collect::<String>();
 
                         Args::new(content.trim(), &self.configuration.delimiters)
                     };

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -971,9 +971,9 @@ impl Framework for StandardFramework {
 
                     let mut args = {
                         let content = message.content.chars().skip(position).skip_while(|x| x.is_whitespace())
-                            .skip(built.chars().count()).collect::<String>();
+                            .skip(command_length).collect::<String>();
 
-                        Args::new(content.trim(), &self.configuration.delimiters)
+                        Args::new(&content.trim(), &self.configuration.delimiters)
                     };
 
                     let before = self.before.clone();


### PR DESCRIPTION
If a user mentioned the bot, Serenity would simply ignore spaces between the mention-end and the rest because zero spaces were expected.

The solution is to split at the mention's end and then skip all whitespaces.

On another note, this should fix compiling.