### PR TITLE
Fix voice websocket loop termination

### DIFF
--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -489,7 +489,7 @@ fn start_threads(client: Arc<Mutex<Client>>, udp: &UdpSocket) -> Result<ThreadIt
                     },
                 };
 
-                if tx_clone.send(ReceiverStatus::Websocket(msg)).is_ok() {
+                if tx_clone.send(ReceiverStatus::Websocket(msg)).is_err() {
                     return;
                 }
             }


### PR DESCRIPTION
The websocket loop for voice events is terminated whenever a websocket
message is successfully sent. This is caused by a bug that was
introduced in https://github.com/zeyla/serenity/commit/c8536c111117f26833fb1bceff734ac1abc55479#diff-6a8a0bad68abd05790cdc2c2ba043ec6L457, due to an improperly implemented clippy lint.