### PR TITLE
Multiple audio stream playback, volume control, pausing

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -5,6 +5,8 @@ pub const EMBED_MAX_LENGTH: u16 = 6000;
 /// The gateway version used by the library. The gateway URI is retrieved via
 /// the REST API.
 pub const GATEWAY_VERSION: u8 = 6;
+/// The voice gateway version used by the library.
+pub const VOICE_GATEWAY_VERSION: u8 = 3;
 /// The large threshold to send on identify.
 pub const LARGE_THRESHOLD: u8 = 250;
 /// The maximum unicode code points allowed within a message by Discord.

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -39,6 +39,7 @@ pub enum AudioType {
 pub struct Audio {
     pub playing: bool,
     pub volume: f32,
+    pub finished: bool,
 
     pub src: Box<AudioSource>,
 }
@@ -48,6 +49,7 @@ impl Audio {
         Self {
             playing: true,
             volume: 1.0,
+            finished: false,
 
             src: source,
         }

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -34,14 +34,14 @@ pub enum AudioType {
 }
 
 /// Control object for audio playback.
+///
 /// Accessed by both commands and the playback code -- as such, access is
 /// always guarded.
 pub struct Audio {
     pub playing: bool,
     pub volume: f32,
     pub finished: bool,
-
-    pub src: Box<AudioSource>,
+    pub source: Box<AudioSource>,
 }
 
 impl Audio {
@@ -50,28 +50,31 @@ impl Audio {
             playing: true,
             volume: 1.0,
             finished: false,
-
-            src: source,
+            source,
         }
     }
 
     pub fn play(&mut self) -> &mut Self {
         self.playing = true;
+
         self
     }
 
     pub fn pause(&mut self) -> &mut Self {
         self.playing = false;
+
         self
     }
 
     pub fn volume(&mut self, volume: f32) -> &mut Self {
         self.volume = volume;
+
         self
     }
 }
 
-/// Threadsafe form of the `Audio` object.
+/// Threadsafe form of an instance of the [`Audio`] struct, locked behind a
+/// Mutex.
 ///
-/// [`Audio`]: #Audio
-pub type TSAudio = Arc<Mutex<Audio>>;
+/// [`Audio`]: struct.Audio.html
+pub type LockedAudio = Arc<Mutex<Audio>>;

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -1,3 +1,6 @@
+use parking_lot::Mutex;
+use std::sync::Arc;
+
 pub const HEADER_LEN: usize = 12;
 pub const SAMPLE_RATE: u32 = 48_000;
 
@@ -32,16 +35,16 @@ pub enum AudioType {
 
 /// Control object for audio playback.
 /// Accessed by both commands and the playback code -- as such, access is
-/// always guarded by [`RwLock`]s.
+/// always guarded.
 pub struct Audio {
     pub playing: bool,
     pub volume: f32,
 
-    pub src: Option<Box<AudioSource>>,
+    pub src: Box<AudioSource>,
 }
 
 impl Audio {
-    pub fn new(source: Option<Box<AudioSource>>) -> Self {
+    pub fn new(source: Box<AudioSource>) -> Self {
         Self {
             playing: true,
             volume: 1.0,
@@ -60,3 +63,8 @@ impl Audio {
         self
     }
 }
+
+/// Threadsafe form of the `Audio` object.
+///
+/// [`Audio`]: #Audio
+pub type TSAudio = Arc<Mutex<Audio>>;

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -29,3 +29,34 @@ pub enum AudioType {
     Opus,
     Pcm,
 }
+
+/// Control object for audio playback.
+/// Accessed by both commands and the playback code -- as such, access is
+/// always guarded by [`RwLock`]s.
+pub struct Audio {
+    pub playing: bool,
+    pub volume: f32,
+
+    pub src: Option<Box<AudioSource>>,
+}
+
+impl Audio {
+    pub fn new(source: Option<Box<AudioSource>>) -> Self {
+        Self {
+            playing: true,
+            volume: 1.0,
+
+            src: source,
+        }
+    }
+
+    pub fn play(&mut self) -> &mut Self {
+        self.playing = true;
+        self
+    }
+
+    pub fn pause(&mut self) -> &mut Self {
+        self.playing = false;
+        self
+    }
+}

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -62,6 +62,11 @@ impl Audio {
         self.playing = false;
         self
     }
+
+    pub fn volume(&mut self, volume: f32) -> &mut Self {
+        self.volume = volume;
+        self
+    }
 }
 
 /// Threadsafe form of the `Audio` object.

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -22,7 +22,7 @@ use std::sync::mpsc::{self, Receiver as MpscReceiver, Sender as MpscSender};
 use std::sync::Arc;
 use std::thread::{self, Builder as ThreadBuilder, JoinHandle};
 use std::time::Duration;
-use super::audio::{AudioReceiver, AudioSource, AudioType, HEADER_LEN, SAMPLE_RATE};
+use super::audio::{Audio, AudioReceiver, AudioSource, AudioType, HEADER_LEN, SAMPLE_RATE};
 use super::connection_info::ConnectionInfo;
 use super::{payload, VoiceError, CRYPTO_MODE};
 use websocket::client::Url as WebsocketUrl;

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -348,9 +348,8 @@ impl Connection {
             if self.silence_frames > 0 {
                 self.silence_frames -= 1;
 
-                for value in &mut buffer[..] {
-                    *value = 0;
-                }
+                // Explicit "Silence" frame.
+                opus_frame.extend_from_slice(&[0xf, 0x8, 0xf, 0xf, 0xf, 0xe]);
             } else {
                 // Per official guidelines, send 5x silence BEFORE we stop speaking.
                 self.set_speaking(false)?;

--- a/src/voice/handler.rs
+++ b/src/voice/handler.rs
@@ -6,7 +6,7 @@ use parking_lot::Mutex;
 use std::sync::Arc;
 use std::sync::mpsc::{self, Sender as MpscSender};
 use super::connection_info::ConnectionInfo;
-use super::{Audio, AudioReceiver, AudioSource, Status as VoiceStatus, threading, TSAudio};
+use super::{Audio, AudioReceiver, AudioSource, Status as VoiceStatus, threading, LockedAudio};
 
 /// The handler is responsible for "handling" a single voice connection, acting
 /// as a clean API above the inner connection.
@@ -251,25 +251,34 @@ impl Handler {
         }
     }
 
-    /// Plays audio from a source. This can be a source created via
-    /// [`voice::ffmpeg`] or [`voice::ytdl`].
+    /// Plays audio from a source.
+    ///
+    /// This can be a source created via [`voice::ffmpeg`] or [`voice::ytdl`].
     ///
     /// [`voice::ffmpeg`]: fn.ffmpeg.html
     /// [`voice::ytdl`]: fn.ytdl.html
-    pub fn play(&mut self, source: Box<AudioSource>) -> TSAudio {
+    pub fn play(&mut self, source: Box<AudioSource>) {
+        self.play_returning(source);
+    }
+
+    /// Plays audio from a source, returning the locked audio source.
+    pub fn play_returning(&mut self, source: Box<AudioSource>) -> LockedAudio {
         let player = Arc::new(Mutex::new(Audio::new(source)));
         self.send(VoiceStatus::AddSender(player.clone()));
+
         player
     }
 
     /// Plays audio from a source.
+    ///
     /// Unlike `play`, this stops all other sources attached
     /// to the channel.
     ///
     /// [`play`]: #method.play
-    pub fn play_only(&mut self, source: Box<AudioSource>) -> TSAudio {
+    pub fn play_only(&mut self, source: Box<AudioSource>) -> LockedAudio {
         let player = Arc::new(Mutex::new(Audio::new(source)));
         self.send(VoiceStatus::SetSender(Some(player.clone())));
+
         player
     }
 

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -11,7 +11,7 @@ mod payload;
 mod streamer;
 mod threading;
 
-pub use self::audio::{Audio, AudioReceiver, AudioSource, AudioType, TSAudio};
+pub use self::audio::{Audio, AudioReceiver, AudioSource, AudioType, LockedAudio};
 pub use self::dca::DcaMetadata;
 pub use self::error::{DcaError, VoiceError};
 pub use self::handler::Handler;
@@ -26,6 +26,6 @@ pub(crate) enum Status {
     Connect(ConnectionInfo),
     #[allow(dead_code)] Disconnect,
     SetReceiver(Option<Box<AudioReceiver>>),
-    SetSender(Option<TSAudio>),
-    AddSender(TSAudio),
+    SetSender(Option<LockedAudio>),
+    AddSender(LockedAudio),
 }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -11,16 +11,14 @@ mod payload;
 mod streamer;
 mod threading;
 
-pub use self::audio::{Audio, AudioReceiver, AudioSource, AudioType};
+pub use self::audio::{Audio, AudioReceiver, AudioSource, AudioType, TSAudio};
 pub use self::dca::DcaMetadata;
 pub use self::error::{DcaError, VoiceError};
 pub use self::handler::Handler;
 pub use self::manager::Manager;
 pub use self::streamer::{dca, ffmpeg, opus, pcm, ytdl};
 
-use parking_lot::Mutex;
 use self::connection_info::ConnectionInfo;
-use std::sync::Arc;
 
 const CRYPTO_MODE: &'static str = "xsalsa20_poly1305";
 
@@ -28,6 +26,6 @@ pub(crate) enum Status {
     Connect(ConnectionInfo),
     #[allow(dead_code)] Disconnect,
     SetReceiver(Option<Box<AudioReceiver>>),
-    SetSender(Option<Box<AudioSource>>),
-    AddSender(Arc<Mutex<Audio>>),
+    SetSender(Option<TSAudio>),
+    AddSender(TSAudio),
 }

--- a/src/voice/mod.rs
+++ b/src/voice/mod.rs
@@ -11,14 +11,16 @@ mod payload;
 mod streamer;
 mod threading;
 
-pub use self::audio::{AudioReceiver, AudioSource, AudioType};
+pub use self::audio::{Audio, AudioReceiver, AudioSource, AudioType};
 pub use self::dca::DcaMetadata;
 pub use self::error::{DcaError, VoiceError};
 pub use self::handler::Handler;
 pub use self::manager::Manager;
 pub use self::streamer::{dca, ffmpeg, opus, pcm, ytdl};
 
+use parking_lot::Mutex;
 use self::connection_info::ConnectionInfo;
+use std::sync::Arc;
 
 const CRYPTO_MODE: &'static str = "xsalsa20_poly1305";
 
@@ -27,4 +29,5 @@ pub(crate) enum Status {
     #[allow(dead_code)] Disconnect,
     SetReceiver(Option<Box<AudioReceiver>>),
     SetSender(Option<Box<AudioSource>>),
+    AddSender(Arc<Mutex<Audio>>),
 }

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -42,6 +42,9 @@ fn runner(rx: &MpscReceiver<Status>) {
                 Ok(Status::SetSender(s)) => {
                     sender = s;
                 },
+                Ok(Status::AddSender(s)) => {
+                    unimplemented!();
+                },
                 Err(TryRecvError::Empty) => {
                     // If we receieved nothing, then we can perform an update.
                     break;

--- a/src/voice/threading.rs
+++ b/src/voice/threading.rs
@@ -15,7 +15,7 @@ pub(crate) fn start(guild_id: GuildId, rx: MpscReceiver<Status>) {
 }
 
 fn runner(rx: &MpscReceiver<Status>) {
-    let mut sender = None;
+    let mut senders = Vec::new();
     let mut receiver = None;
     let mut connection = None;
     let mut timer = Timer::new(20);
@@ -40,10 +40,14 @@ fn runner(rx: &MpscReceiver<Status>) {
                     receiver = r;
                 },
                 Ok(Status::SetSender(s)) => {
-                    sender = s;
+                    senders.clear();
+
+                    if let Some(aud) = s {
+                        senders.push(aud);
+                    }
                 },
                 Ok(Status::AddSender(s)) => {
-                    unimplemented!();
+                    senders.push(s);
                 },
                 Err(TryRecvError::Empty) => {
                     // If we receieved nothing, then we can perform an update.
@@ -65,7 +69,7 @@ fn runner(rx: &MpscReceiver<Status>) {
         // another event.
         let error = match connection.as_mut() {
             Some(connection) => {
-                let cycle = connection.cycle(&mut sender, &mut receiver, &mut timer);
+                let cycle = connection.cycle(&mut senders, &mut receiver, &mut timer);
 
                 match cycle {
                     Ok(()) => false,


### PR DESCRIPTION
Changes `Handler::play(...)` to return a shared memory object allowing some ongoing control of active audio clips. This should allow for more detailed control in future e.g. events tied to sound playback, termination, etc.

Crucially, users can now simultaneously play multiple streams over one voice connection.
Accordingly, this changes the PCM pipeline to combine all incoming streams in `f32` space.
At present, I am not decoding explicit Opus frames to join them in this fashion.
Old functionality is recreated in `Handler::play_only(...)`.

I expect some of the struct names/organisation may not be the best, feedback would be much appreciated.