### PR TITLE
Add a way to reorder roles

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -854,6 +854,21 @@ pub fn edit_role_position(guild_id: u64, role_id: u64, position: u64) -> Result<
         .map_err(From::from)
 }
 
+/// Edits the positions of a guild's roles.
+pub fn edit_role_positions(guild_id: u64, value: &Value) -> Result<Vec<Role>> {
+    let body = serde_json::to_string(value)?;
+
+    let response = request!(
+        Route::GuildsIdRoles(guild_id),
+        patch(body),
+        "/guilds/{}/roles",
+        guild_id
+    );
+
+    serde_json::from_reader::<HyperResponse, Vec<Role>>(response)
+        .map_err(From::from)
+}
+
 /// Edits a the webhook with the given data.
 ///
 /// The Value is a map with optional values of:

--- a/src/model/guild/guild_id.rs
+++ b/src/model/guild/guild_id.rs
@@ -457,6 +457,24 @@ impl GuildId {
         http::edit_guild_channel_positions(self.0, &Value::Array(items))
     }
 
+    /// Re-orders the roles of the guild.
+    ///
+    /// Accepts an iterator of a tuple of the role ID to modify and its new
+    /// position.
+    ///
+    /// Although not required, you should specify all roles' positions,
+    /// regardless of whether they were updated. Otherwise, positioning can
+    /// sometimes get weird.
+    pub fn reorder_roles<It>(&self, roles: It) -> Result<Vec<Role>>
+        where It: IntoIterator<Item = (RoleId, u64)> {
+        let items = roles.into_iter().map(|(id, pos)| json!({
+            "id": id,
+            "position": pos,
+        })).collect();
+
+        http::edit_role_positions(self.0, &Value::Array(items))
+    }
+
     /// Returns the Id of the shard associated with the guild.
     ///
     /// When the cache is enabled this will automatically retrieve the total

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1355,6 +1355,16 @@ impl Guild {
         self.id.reorder_channels(channels)
     }
 
+    /// Re-orders the roles of the guild.
+    ///
+    /// Although not required, you should specify all roles' positions,
+    /// regardless of whether they were updated. Otherwise, positioning can
+    /// sometimes get weird.
+    pub fn reorder_roles<It>(&self, roles: It) -> Result<Vec<Role>>
+        where It: IntoIterator<Item = (RoleId, u64)> {
+        self.id.reorder_roles(roles)
+    }
+
     /// Returns the Id of the shard associated with the guild.
     ///
     /// When the cache is enabled this will automatically retrieve the total


### PR DESCRIPTION
Adds [this](https://discordapp.com/developers/docs/resources/guild#modify-guild-role-positions) route, used to reorder roles in a guild.

The Discord docs say that this route only requires the `MANAGE_ROLES` permission, but my tests were consistently giving me permission errors. This makes me wonder if bots can even use this route, if my server was just messed up, or if the code is bad.

A review would be nice.