### PR TITLE
Add unrecognised command

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -121,6 +121,11 @@ fn main() {
                 Err(why) => println!("Command '{}' returned error {:?}", command_name, why),
             }
         })
+        // Set a function that's called whenever an attempted command-call's
+        // command could not be found.
+        .unrecognised_command(|_, _, unknown_command_name| {
+            println!("Could not find command named '{}'", unknown_command_name);
+        })
         // Set a function that's called whenever a command's execution didn't complete for one
         // reason or another. For example, when a user has exceeded a rate-limit or a command
         // can only be performed by the bot owner.

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -32,6 +32,7 @@ impl HelpCommand for Help {
 
 pub type BeforeHook = Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
 pub type AfterHook = Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
+pub type UnrecognisedCommandHook = Fn(&mut Context, &Message, &str) + Send + Sync + 'static;
 pub(crate) type InternalCommand = Arc<Command>;
 pub type PrefixCheck = Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -896,7 +896,7 @@ impl StandardFramework {
     /// use serenity::framework::StandardFramework;
     ///
     /// client.with_framework(StandardFramework::new()
-    ///     .unrecognised_command(|ctx, msg| { }));
+    ///     .unrecognised_command(|ctx, msg, unrecognised_command_name| { }));
     /// ```
     pub fn unrecognised_command<F>(mut self, f: F) -> Self
         where F: Fn(&mut Context, &Message, &str) + Send + Sync + 'static {


### PR DESCRIPTION
As requested in issue #275, this PR adds the functionality to call a function (`unrecognised_command`) whenever the dispatcher fails finding a sent command.