### PR TITLE
Drop implementation for ffmpeg container (#277)

### DIFF
--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -16,6 +16,12 @@ impl Read for ChildContainer {
     }
 }
 
+impl Drop for ChildContainer {
+    fn drop (&mut self) {
+        self.0.wait().expect("couldn't drop child process -- not running?");
+    }
+}
+
 struct InputSource<R: Read + Send + 'static> {
     stereo: bool,
     reader: R,

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -18,7 +18,9 @@ impl Read for ChildContainer {
 
 impl Drop for ChildContainer {
     fn drop (&mut self) {
-        self.0.wait().expect("couldn't drop child process -- not running?");
+        if let Err(e) = self.0.wait() {
+            debug!("[Voice] Error awaiting child process: {:?}", e);
+        }
     }
 }
 


### PR DESCRIPTION
Simple edit, should prevent zombie ffmpeg processes.
Unsure if this should be prepended by a `.kill()` call, but this seems to work in practice.