### PR TITLE
Teach CreateHelpCommand lacking_ownership

### DIFF
--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -121,6 +121,11 @@ fn main() {
                 Err(why) => println!("Command '{}' returned error {:?}", command_name, why),
             }
         })
+        // Set a function that's called whenever an attempted command-call's
+        // command could not be found.
+        .unrecognised_command(|_, _, unknown_command_name| {
+            println!("Could not find command named '{}'", unknown_command_name);
+        })
         // Set a function that's called whenever a command's execution didn't complete for one
         // reason or another. For example, when a user has exceeded a rate-limit or a command
         // can only be performed by the bot owner.

--- a/examples/05_command_framework/src/main.rs
+++ b/examples/05_command_framework/src/main.rs
@@ -153,17 +153,20 @@ fn main() {
                 .suggestion_text("How about this command: {}, it's numero uno on the market...!")
                 // On another note, you can set up the help-menu-filter-behaviour.
                 // Here are all possible settings shown on all possible options.
-                // First case is if a user lacks permissions for a command, we can hide the command.
+                // If a user lacks permissions for a command, we can `Hide` the command.
                 .lacking_permissions(HelpBehaviour::Hide)
-                // If the user is nothing but lacking a certain role, we just display it hence our variant is `Nothing`.
+                // If a user lacks a certain role for a command, we can do `Nothing` to its listing
+                // and display it.
                 .lacking_role(HelpBehaviour::Nothing)
-                // The last `enum`-variant is `Strike`, which ~~strikes~~ a command.
+                // If a user lacks bot ownership for an owners-only command, we can ~~`Strike`~~ it.
+                .lacking_ownership(HelpBehaviour::Strike)
+                // If a user is in the wrong channel for a command, we can ~~`Strike`~~ it.
                 .wrong_channel(HelpBehaviour::Strike)
-                // Serenity will automatically analyse and generate a hint/tip explaining the possible
-                // cases of a command being ~~striked~~, but only  if
-                // `striked_commands_tip(Some(""))` keeps `Some()` wrapping an empty `String`, which is the default value.
-                // If the `String` is not empty, your given `String` will be used instead.
-                // If you pass in a `None`, no hint will be displayed at all.
+                // Serenity will automatically analyse and generate a hint/tip explaining the
+                // possible cases of a command being ~~striked~~, but only  if
+                // `striked_commands_tip(Some(""))` keeps `Some()` wrapping an empty `String`, which
+                // is the default value.  If the `String` is not empty, your given `String` will be
+                // used instead.  If you pass in a `None`, no hint will be displayed at all.
                  })
         .command("commands", |c| c
             // Make this command use the "complicated" bucket.

--- a/src/client/event_handler.rs
+++ b/src/client/event_handler.rs
@@ -6,80 +6,283 @@ use std::sync::Arc;
 use super::context::Context;
 use ::client::bridge::gateway::event::*;
 
+/// The core trait for handling events by serenity.
 pub trait EventHandler {
+    /// Dispatched when the cache gets full.
+    /// 
+    /// Provides the cached guilds' ids.
     #[cfg(feature = "cache")]
     fn cached(&self, _: Context, _: Vec<GuildId>) {}
+
+    /// Dispatched when a channel is created.
+    /// 
+    /// Provides said channel's data.
     fn channel_create(&self, _: Context, _: Arc<RwLock<GuildChannel>>) {}
+
+    /// Dispatched when a category is created.
+    /// 
+    /// Provides said category's data.
     fn category_create(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
+
+    /// Dispatched when a category is deleted.
+    /// 
+    /// Provides said category's data.
     fn category_delete(&self, _: Context, _: Arc<RwLock<ChannelCategory>>) {}
+
+    /// Dispatched when a private channel is created.
+    /// 
+    /// Provides said channel's data.
     fn private_channel_create(&self, _: Context, _: Arc<RwLock<PrivateChannel>>) {}
+
+    /// Dispatched when a channel is deleted.
+    /// 
+    /// Provides said channel's data.
     fn channel_delete(&self, _: Context, _: Arc<RwLock<GuildChannel>>) {}
+
+    /// Dispatched when a pin is added, deleted.
+    /// 
+    /// Provides said pin's data.
     fn channel_pins_update(&self, _: Context, _: ChannelPinsUpdateEvent) {}
+
+    /// Dispatched when a user is added to a `Group`.
+    /// 
+    /// Provides the group's id and the user's data.
     fn channel_recipient_addition(&self, _: Context, _: ChannelId, _: User) {}
+
+    /// Dispatched when a user is removed to a `Group`.
+    /// 
+    /// Provides the group's id and the user's data.
     fn channel_recipient_removal(&self, _: Context, _: ChannelId, _: User) {}
+
+    /// Dispatched when a channel is updated.
+    /// 
+    /// Provides the old channel data, and the new data.
     #[cfg(feature = "cache")]
     fn channel_update(&self, _: Context, _: Option<Channel>, _: Channel) {}
+
+    /// Dispatched when a channel is updated.
+    /// 
+    /// Provides the new data.
     #[cfg(not(feature = "cache"))]
     fn channel_update(&self, _: Context, _: Channel) {}
+
+    /// Dispatched when a user is banned from a guild.
+    /// 
+    /// Provides the guild's id and the banned user's data.
     fn guild_ban_addition(&self, _: Context, _: GuildId, _: User) {}
+
+    /// Dispatched when a user's ban is lifted from a guild.
+    /// 
+    /// /// Provides the guild's id and the lifted user's data.
     fn guild_ban_removal(&self, _: Context, _: GuildId, _: User) {}
+
+    /// Dispatched when a guild is created; 
+    /// or an existing guild's data is sent to us.
+    /// 
+    /// Provides the guild's data and whether the guild is new.
     #[cfg(feature = "cache")]
     fn guild_create(&self, _: Context, _: Guild, _: bool) {}
+
+    /// Dispatched when a guild is created; 
+    /// or an existing guild's data is sent to us.
+    /// 
+    /// Provides the guild's data.
     #[cfg(not(feature = "cache"))]
     fn guild_create(&self, _: Context, _: Guild) {}
+
+    /// Dispatched when a guild is deleted.
+    /// 
+    /// Provides the partial data of the guild sent by discord,
+    /// and the full data from the cache, if available.
     #[cfg(feature = "cache")]
     fn guild_delete(&self, _: Context, _: PartialGuild, _: Option<Arc<RwLock<Guild>>>) {}
+
+    /// Dispatched when a guild is deleted.
+    /// 
+    /// Provides the partial data of the guild sent by discord.
     #[cfg(not(feature = "cache"))]
     fn guild_delete(&self, _: Context, _: PartialGuild) {}
+
+    /* the emojis were updated. */
+
+    /// Dispatched when the emojis are updated.
+    /// 
+    /// Provides the guild's id and the new state of the emojis in the guild.
     fn guild_emojis_update(&self, _: Context, _: GuildId, _: HashMap<EmojiId, Emoji>) {}
+
+    /// Dispatched when a guild's integration is added, updated or removed.
+    /// 
+    /// Provides the guild's id.
     fn guild_integrations_update(&self, _: Context, _: GuildId) {}
+
+    /// Dispatched when a user joins a guild.
+    /// 
+    /// Provides the guild's id and the user's member data.
     fn guild_member_addition(&self, _: Context, _: GuildId, _: Member) {}
+
+    /// Dispatched when a user is removed (kicked).
+    /// 
+    /// Provides the guild's id, the user's data, and the user's member data if available.
     #[cfg(feature = "cache")]
     fn guild_member_removal(&self, _: Context, _: GuildId, _: User, _: Option<Member>) {}
+
+    /// Dispatched when a user is removed (kicked).
+    /// 
+    /// Provides the guild's id, the user's data.
     #[cfg(not(feature = "cache"))]
     fn guild_member_removal(&self, _: Context, _: GuildId, _: User) {}
+
+    /// Dispatched when a member is updated (e.g their nickname is updated)
+    /// 
+    /// Provides the member's old data (if available) and the new data.
     #[cfg(feature = "cache")]
     fn guild_member_update(&self, _: Context, _: Option<Member>, _: Member) {}
+
+    /// Dispatched when a member is updated (e.g their nickname is updated)
+    /// 
+    /// Provides the new data.
     #[cfg(not(feature = "cache"))]
     fn guild_member_update(&self, _: Context, _: GuildMemberUpdateEvent) {}
+
+    /// Dispatched when the data for offline members was requested.
+    /// 
+    /// Provides the guild's id and the data. 
     fn guild_members_chunk(&self, _: Context, _: GuildId, _: HashMap<UserId, Member>) {}
+
+    /// Dispatched when a role is created.
+    /// 
+    /// Provides the guild's id and the new role's data.
     fn guild_role_create(&self, _: Context, _: GuildId, _: Role) {}
+
+    /// Dispatched when a role is deleted.
+    /// 
+    /// Provides the guild's id, the role's id and its data if available.
     #[cfg(feature = "cache")]
     fn guild_role_delete(&self, _: Context, _: GuildId, _: RoleId, _: Option<Role>) {}
+
+    /// Dispatched when a role is deleted.
+    /// 
+    /// Provides the guild's id, the role's id.
     #[cfg(not(feature = "cache"))]
     fn guild_role_delete(&self, _: Context, _: GuildId, _: RoleId) {}
+
+    /// Dispatched when a role is updated.
+    /// 
+    /// Provides the guild's id, the role's old (if available) and new data.
     #[cfg(feature = "cache")]
     fn guild_role_update(&self, _: Context, _: GuildId, _: Option<Role>, _: Role) {}
+
+    /// Dispatched when a role is updated.
+    /// 
+    /// Provides the guild's id and the role's new data.
     #[cfg(not(feature = "cache"))]
     fn guild_role_update(&self, _: Context, _: GuildId, _: Role) {}
+
+    /// Dispatched when a guild became unavailable.
+    /// 
+    /// Provides the guild's id. 
     fn guild_unavailable(&self, _: Context, _: GuildId) {}
+
+    /// Dispatched when the guild is updated.
+    /// 
+    /// Provides the guild's old full data (if available) and the new, albeit partial data.
     #[cfg(feature = "cache")]
     fn guild_update(&self, _: Context, _: Option<Arc<RwLock<Guild>>>, _: PartialGuild) {}
+
+    /// Dispatched when the guild is updated.
+    /// 
+    /// Provides the guild's new, albeit partial data.
     #[cfg(not(feature = "cache"))]
     fn guild_update(&self, _: Context, _: PartialGuild) {}
+
+    /// Dispatched when a message is created.
+    /// 
+    /// Provides the message's data.
     fn message(&self, _: Context, _: Message) {}
+
+    /// Dispatched when a message is deleted.
+    /// 
+    /// Provides the channel's id and the message's id.
     fn message_delete(&self, _: Context, _: ChannelId, _: MessageId) {}
+
+    /// Dispatched when multiple messages were deleted at once.
+    /// 
+    /// Provides the channel's id and the deleted messages' ids.
     fn message_delete_bulk(&self, _: Context, _: ChannelId, _: Vec<MessageId>) {}
+
+    /// Dispatched when a new reaction is attached to a message.
+    /// 
+    /// Provides the reaction's data.
     fn reaction_add(&self, _: Context, _: Reaction) {}
+
+    /// Dispatched when a reaction is dettached from a message.
+    /// 
+    /// Provides the reaction's data.
     fn reaction_remove(&self, _: Context, _: Reaction) {}
+
+    /// Dispatched when all reactions of a message are dettached from a message.
+    /// 
+    /// Provides the channel's id and the message's id.
     fn reaction_remove_all(&self, _: Context, _: ChannelId, _: MessageId) {}
+
+    /// Dispatched when a message is updated.
+    /// 
+    /// Provides the new data of the message.
     fn message_update(&self, _: Context, _: MessageUpdateEvent) {}
+
     fn presence_replace(&self, _: Context, _: Vec<Presence>) {}
+
+    /// Dispatched when a user's presence is updated (i.e off -> on).
+    /// 
+    /// Provides the presence's new data.
     fn presence_update(&self, _: Context, _: PresenceUpdateEvent) {}
+
+    /// Dispatched upon startup.
+    /// 
+    /// Provides data about the bot and the guilds it's in.
     fn ready(&self, _: Context, _: Ready) {}
+
+    /// Dispatched upon reconnection.
     fn resume(&self, _: Context, _: ResumedEvent) {}
 
-    /// Called when a shard's connection stage is updated, providing the context
-    /// of the shard and the event information about the update.
+    /// Dispatched when a shard's connection stage is updated
+    /// 
+    /// Provides the context of the shard and the event information about the update.
     fn shard_stage_update(&self, _: Context, _: ShardStageUpdateEvent) {}
 
+    /// Dispatched when a user starts typing.
     fn typing_start(&self, _: Context, _: TypingStartEvent) {}
+
+    /// Dispatched when an unknown event was sent from discord.
+    /// 
+    /// Provides the event's name and its unparsed data.
     fn unknown(&self, _: Context, _: String, _: Value) {}
+
+    /// Dispatched when the bot's data is updated.
+    /// 
+    /// Provides the old and new data.
     #[cfg(feature = "cache")]
     fn user_update(&self, _: Context, _: CurrentUser, _: CurrentUser) {}
+
+    /// Dispatched when the bot's data is updated.
+    /// 
+    /// Provides the new data.
     #[cfg(not(feature = "cache"))]
     fn user_update(&self, _: Context, _: CurrentUser) {}
+
+    /// Dispatched when a guild's voice server was updated (or changed to another one).
+    /// 
+    /// Provides the voice server's data.
     fn voice_server_update(&self, _: Context, _: VoiceServerUpdateEvent) {}
+
+    /// Dispatched when a user joins, leaves or moves a voice channel.
+    /// 
+    /// Provides the guild's id (if available) and 
+    /// the new state of the guild's voice channels.
     fn voice_state_update(&self, _: Context, _: Option<GuildId>, _: VoiceState) {}
+
+    /// Dispatched when a guild's webhook is updated.
+    /// 
+    /// Provides the guild's id and the channel's id the webhook belongs in.
     fn webhook_update(&self, _: Context, _: GuildId, _: ChannelId) {}
 }

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -1,7 +1,8 @@
 use client::Context;
 use model::channel::Message;
+use model::id::UserId;
 use model::Permissions;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
@@ -13,7 +14,7 @@ pub type Check = Fn(&mut Context, &Message, &mut Args, &CommandOptions) -> bool
                      + Sync
                      + 'static;
 
-pub type HelpFunction = fn(&mut Context, &Message, &HelpOptions, HashMap<String, Arc<CommandGroup>>, &Args)
+pub type HelpFunction = fn(&mut Context, &Message, &HelpOptions, HashMap<String, Arc<CommandGroup>>, HashSet<UserId>, &Args)
                    -> Result<(), Error>;
 
 pub struct Help(pub HelpFunction, pub Arc<HelpOptions>);
@@ -25,8 +26,8 @@ impl Debug for Help {
 }
 
 impl HelpCommand for Help {
-    fn execute(&self, c: &mut Context, m: &Message, ho: &HelpOptions,hm: HashMap<String, Arc<CommandGroup>>, a: &Args) -> Result<(), Error> {
-        (self.0)(c, m, ho, hm, a)
+    fn execute(&self, c: &mut Context, m: &Message, ho: &HelpOptions, gs: HashMap<String, Arc<CommandGroup>>, os: HashSet<UserId>, a: &Args) -> Result<(), Error> {
+        (self.0)(c, m, ho, gs, os, a)
     }
 }
 
@@ -167,6 +168,8 @@ pub struct HelpOptions {
     pub lacking_role: HelpBehaviour,
     /// If a user lacks permissions, this will treat how these commands will be displayed.
     pub lacking_permissions: HelpBehaviour,
+    /// If a user isn't the owner, this will treat how these commands will be displayed.
+    pub lacking_ownership: HelpBehaviour,
     /// If a user is using the help-command in a channel where a command is not available,
     /// this behaviour will be executed.
     pub wrong_channel: HelpBehaviour,
@@ -177,7 +180,7 @@ pub struct HelpOptions {
 }
 
 pub trait HelpCommand: Send + Sync + 'static {
-    fn execute(&self, &mut Context, &Message, &HelpOptions, HashMap<String, Arc<CommandGroup>>, &Args) -> Result<(), Error>;
+    fn execute(&self, &mut Context, &Message, &HelpOptions, HashMap<String, Arc<CommandGroup>>, HashSet<UserId>, &Args) -> Result<(), Error>;
 
     fn options(&self) -> Arc<CommandOptions> {
         Arc::clone(&DEFAULT_OPTIONS)
@@ -185,8 +188,8 @@ pub trait HelpCommand: Send + Sync + 'static {
 }
 
 impl HelpCommand for Arc<HelpCommand> {
-    fn execute(&self, c: &mut Context, m: &Message, ho: &HelpOptions, hm: HashMap<String, Arc<CommandGroup>>, a: &Args) -> Result<(), Error> {
-        (**self).execute(c, m, ho, hm, a)
+    fn execute(&self, c: &mut Context, m: &Message, ho: &HelpOptions, gs: HashMap<String, Arc<CommandGroup>>, os: HashSet<UserId>, a: &Args) -> Result<(), Error> {
+        (**self).execute(c, m, ho, gs, os, a)
     }
 }
 
@@ -212,6 +215,7 @@ impl Default for HelpOptions {
             striked_commands_tip: Some(String::new()),
             lacking_role: HelpBehaviour::Strike,
             lacking_permissions: HelpBehaviour::Strike,
+            lacking_ownership: HelpBehaviour::Hide,
             wrong_channel: HelpBehaviour::Strike,
             embed_error_colour: Colour::dark_red(),
             embed_success_colour: Colour::rosewater(),

--- a/src/framework/standard/command.rs
+++ b/src/framework/standard/command.rs
@@ -32,6 +32,7 @@ impl HelpCommand for Help {
 
 pub type BeforeHook = Fn(&mut Context, &Message, &str) -> bool + Send + Sync + 'static;
 pub type AfterHook = Fn(&mut Context, &Message, &str, Result<(), Error>) + Send + Sync + 'static;
+pub type UnrecognisedCommandHook = Fn(&mut Context, &Message, &str) + Send + Sync + 'static;
 pub(crate) type InternalCommand = Arc<Command>;
 pub type PrefixCheck = Fn(&mut Context, &Message) -> Option<String> + Send + Sync + 'static;
 

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -25,7 +25,7 @@ use model::channel::Message;
 use model::guild::{Guild, Member};
 use model::id::{ChannelId, GuildId, UserId};
 use model::Permissions;
-use self::command::{AfterHook, BeforeHook};
+use self::command::{AfterHook, BeforeHook, UnrecognisedCommandHook};
 use std::collections::HashMap;
 use std::default::Default;
 use std::sync::Arc;
@@ -205,6 +205,7 @@ pub struct StandardFramework {
     dispatch_error_handler: Option<Arc<DispatchErrorHook>>,
     buckets: HashMap<String, Bucket>,
     after: Option<Arc<AfterHook>>,
+    unrecognised_command: Option<Arc<UnrecognisedCommandHook>>,
     /// Whether the framework has been "initialized".
     ///
     /// The framework is initialized once one of the following occurs:
@@ -879,6 +880,31 @@ impl StandardFramework {
         self
     }
 
+    /// Specify the function to be called if no command could be dispatched.
+    ///
+    /// # Examples
+    ///
+    /// Using `unrecognised_command`:
+    ///
+    /// ```rust
+    /// # use serenity::prelude::*;
+    /// # struct Handler;
+    /// #
+    /// # impl EventHandler for Handler {}
+    /// # let mut client = Client::new("token", Handler).unwrap();
+    /// #
+    /// use serenity::framework::StandardFramework;
+    ///
+    /// client.with_framework(StandardFramework::new()
+    ///     .unrecognised_command(|ctx, msg, unrecognised_command_name| { }));
+    /// ```
+    pub fn unrecognised_command<F>(mut self, f: F) -> Self
+        where F: Fn(&mut Context, &Message, &str) + Send + Sync + 'static {
+        self.unrecognised_command = Some(Arc::new(f));
+
+        self
+    }
+
     /// Sets what code should be executed when a user sends `(prefix)help`.
     pub fn help(mut self, f: HelpFunction) -> Self {
         let a = CreateHelpCommand(HelpOptions::default(), f).finish();
@@ -909,6 +935,7 @@ impl Framework for StandardFramework {
         threadpool: &ThreadPool,
     ) {
         let res = command::positions(&mut context, &message, &self.configuration);
+        let mut unrecognised_command_name = String::from("");
 
         let positions = match res {
             Some(mut positions) => {
@@ -953,13 +980,14 @@ impl Framework for StandardFramework {
                         built
                     };
 
+                    unrecognised_command_name = built.clone();
                     let cmd = group.commands.get(&built);
 
                     if let Some(&CommandOrAlias::Alias(ref points_to)) = cmd {
                         built = points_to.to_string();
                     }
 
-                    let mut to_check = if let Some(ref prefix) = group.prefix {
+                    let to_check = if let Some(ref prefix) = group.prefix {
                         if built.starts_with(prefix) && command_length > prefix.len() + 1 {
                             built[(prefix.len() + 1)..].to_string()
                         } else {
@@ -1049,6 +1077,14 @@ impl Framework for StandardFramework {
                 }
             }
         }
+
+        let unrecognised_command = self.unrecognised_command.clone();
+
+        threadpool.execute(move || {
+            if let Some(unrecognised_command) = unrecognised_command {
+                (unrecognised_command)(&mut context, &message, &unrecognised_command_name);
+            }
+        });
     }
 
     fn update_current_user(&mut self, user_id: UserId) {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1,4 +1,3 @@
-
 pub mod help_commands;
 
 mod command;
@@ -28,6 +27,7 @@ use model::Permissions;
 use self::command::{AfterHook, BeforeHook, UnrecognisedCommandHook};
 use std::collections::HashMap;
 use std::default::Default;
+use std::ops;
 use std::sync::Arc;
 use super::Framework;
 use threadpool::ThreadPool;
@@ -1013,6 +1013,7 @@ impl Framework for StandardFramework {
 
                         if let Some(help) = help {
                             let groups = self.groups.clone();
+                            let owners = self.configuration.owners.clone();
                             threadpool.execute(move || {
 
                                 if let Some(before) = before {
@@ -1022,7 +1023,7 @@ impl Framework for StandardFramework {
                                     }
                                 }
 
-                                let result = (help.0)(&mut context, &message, &help.1, groups, &args);
+                                let result = (help.0)(&mut context, &message, &help.1, groups, owners, &args);
 
                                 if let Some(after) = after {
                                     (after)(&mut context, &message, &built, result);
@@ -1119,11 +1120,11 @@ pub fn has_correct_roles(cmd: &Arc<CommandOptions>, guild: &Guild, member: &Memb
 }
 
 /// Describes the behaviour the help-command shall execute once it encounters
-/// a command which the user or command fails to meet following criteria :
-/// Lacking required permissions to execute the command.
-/// Lacking required roles to execute the command.
-/// The command can't be used in the current channel (as in `DM only` or `guild only`).
-#[derive(PartialEq, Debug)]
+/// a command which the user or command fails to meet following criteria:
+/// - Lacking required permissions to execute the command.
+/// - Lacking required roles to execute the command.
+/// - The command can't be used in the current channel (as in "DM only" or "guild only").
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum HelpBehaviour {
     /// Strikes a command by applying `~~{comand_name}~~`.
     Strike,
@@ -1140,5 +1141,37 @@ impl fmt::Display for HelpBehaviour {
            HelpBehaviour::Hide => write!(f, "HelpBehaviour::Hide"),
            HelpBehaviour::Nothing => write!(f, "HelBehaviour::Nothing"),
        }
+    }
+}
+
+/// Compares two help behaviours and merges them, preserving stronger behaviour
+/// (`Hide` being stronger than `Strike`, and `Strike` being stronger than
+/// `Nothing`).
+impl ops::Add for HelpBehaviour {
+    type Output = HelpBehaviour;
+    fn add(self, other: HelpBehaviour) -> HelpBehaviour {
+        match self {
+            HelpBehaviour::Strike => match other {
+                HelpBehaviour::Strike => HelpBehaviour::Strike,
+                HelpBehaviour::Nothing => HelpBehaviour::Strike,
+                HelpBehaviour::Hide => HelpBehaviour::Hide,
+            }
+            HelpBehaviour::Nothing => other,
+            HelpBehaviour::Hide => HelpBehaviour::Hide,
+        }
+    }
+}
+
+impl ops::AddAssign for HelpBehaviour {
+    fn add_assign(&mut self, other: HelpBehaviour) {
+        match *self {
+            HelpBehaviour::Strike => match other {
+                HelpBehaviour::Strike => (),
+                HelpBehaviour::Nothing => *self = HelpBehaviour::Strike,
+                HelpBehaviour::Hide => (),
+            }
+            HelpBehaviour::Nothing => *self = other,
+            HelpBehaviour::Hide => (),
+        }
     }
 }

--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -16,6 +16,14 @@ impl Read for ChildContainer {
     }
 }
 
+impl Drop for ChildContainer {
+    fn drop (&mut self) {
+        if let Err(e) = self.0.wait() {
+            debug!("[Voice] Error awaiting child process: {:?}", e);
+        }
+    }
+}
+
 struct InputSource<R: Read + Send + 'static> {
     stereo: bool,
     reader: R,


### PR DESCRIPTION
It takes a `HelpBehaviour` and acts like the other `CreateHelpCommand::lacking_*` functions.

This required changing `HelpFunction` to also take a `HashSet<UserId>` for the owner set, which is a breaking change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zeyla/serenity/279)
<!-- Reviewable:end -->
