### PR TITLE
Pad user discriminators in content_safe to 4 digits

### DIFF
--- a/src/model/channel/message.rs
+++ b/src/model/channel/message.rs
@@ -271,7 +271,7 @@ impl Message {
             at_distinct.push('@');
             at_distinct.push_str(&u.name);
             at_distinct.push('#');
-            let _ = write!(at_distinct, "{}", u.discriminator);
+            let _ = write!(at_distinct, "{:04}", u.discriminator);
             result = result.replace(&u.mention(), &at_distinct);
         }
 


### PR DESCRIPTION
This brings the function in line with the 'tag' function for User models, and with the official Discord app experience and other libraries.

I'm not sure whether or not this constitutes a 'breaking change', but this improves consistency.