### PR TITLE
Check if `len_quoted()` meets `min_args`- and `max_args`-requirement.

### DIFF
--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -513,7 +513,7 @@ impl StandardFramework {
                 }
             }
 
-            let len = args.len();
+            let len = args.len_quoted();
 
             if let Some(x) = command.min_args {
                 if len < x as usize {


### PR DESCRIPTION
Since `len_quoted()` falls back to `len()`'s mechanic if no quotes are found, we can simply check this instead.
Before, we only checked for unquoted `Args`, which might lead to confusion as we support quoted `Args`-parsing.