### PR TITLE
Support sending files with embed

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1734,6 +1734,7 @@ pub fn send_files<'a, T, It: IntoIterator<Item=T>>(channel_id: u64, files: It, m
             Value::Bool(true) => request.write_text(&k, "true")?,
             Value::Number(inner) => request.write_text(&k, inner.to_string())?,
             Value::String(inner) => request.write_text(&k, inner)?,
+            Value::Object(inner) => request.write_text(&k, serde_json::to_string(&inner)?)?,
             _ => continue,
         };
     }

--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -406,9 +406,6 @@ impl ChannelId {
     /// Message contents may be passed by using the [`CreateMessage::content`]
     /// method.
     ///
-    /// An embed can _not_ be sent when sending a file. If you set one, it will
-    /// be automatically removed.
-    ///
     /// The [Attach Files] and [Send Messages] permissions are required.
     ///
     /// **Note**: Message contents must be under 2000 unicode code points.
@@ -472,9 +469,11 @@ impl ChannelId {
             }
         }
 
-        let _ = msg.0.remove(&"embed");
-        let map = utils::vecmap_to_json_map(msg.0);
+        if let Some(e) = msg.0.remove(&"embed") {
+            msg.0.insert("payload_json", json!({ "embed": e }));
+        }
 
+        let map = utils::vecmap_to_json_map(msg.0);
         http::send_files(self.0, files, map)
     }
 


### PR DESCRIPTION
An embed can be sent with files if it is sent under "payload_json".