### PR TITLE
Set `#[cfg(feature="cache")]` for cache-relying sections

### DIFF
--- a/src/client/dispatch.rs
+++ b/src/client/dispatch.rs
@@ -25,7 +25,7 @@ use super::CACHE;
 macro_rules! update {
     ($event:expr) => {
         {
-            #[cfg(feature="cache")]
+            #[cfg(feature = "cache")]
             {
                 CACHE.write().update(&mut $event)
             }

--- a/src/framework/standard/create_command.rs
+++ b/src/framework/standard/create_command.rs
@@ -218,6 +218,7 @@ impl CreateCommand {
     }
 
     /// Sets roles that are allowed to use the command.
+    #[cfg(feature="cache")]
     pub fn allowed_roles<T: ToString, It: IntoIterator<Item=T>>(mut self, allowed_roles: It) -> Self {
         self.0.allowed_roles = allowed_roles.into_iter().map(|x| x.to_string()).collect();
 
@@ -225,7 +226,7 @@ impl CreateCommand {
     }
 
     /// Sets an initialise middleware to be called upon the command's actual registration.
-    /// 
+    ///
     /// This is similiar to implementing the `init` function on `Command`.
     pub fn init<F: Fn() + Send + Sync + 'static>(mut self, f: F) -> Self {
         self.2.init = Some(Arc::new(f));
@@ -234,9 +235,9 @@ impl CreateCommand {
     }
 
     /// Sets a before middleware to be called before the command's execution.
-    /// 
+    ///
     /// This is similiar to implementing the `before` function on `Command`.
-    pub fn before<F: Send + Sync + 'static>(mut self, f: F) -> Self 
+    pub fn before<F: Send + Sync + 'static>(mut self, f: F) -> Self
         where F: Fn(&mut Context, &Message) -> bool {
         self.2.before = Some(Arc::new(f));
 
@@ -244,9 +245,9 @@ impl CreateCommand {
     }
 
     /// Sets an after middleware to be called after the command's execution.
-    /// 
+    ///
     /// This is similiar to implementing the `after` function on `Command`.
-    pub fn after<F: Send + Sync + 'static>(mut self, f: F) -> Self 
+    pub fn after<F: Send + Sync + 'static>(mut self, f: F) -> Self
         where F: Fn(&mut Context, &Message, &Result<(), CommandError>) {
         self.2.after = Some(Arc::new(f));
 

--- a/src/framework/standard/create_group.rs
+++ b/src/framework/standard/create_group.rs
@@ -148,6 +148,7 @@ impl CreateGroup {
     }
 
     /// Sets roles that are allowed to use the command.
+    #[cfg(feature = "cache")]
     pub fn allowed_roles<T: ToString, It: IntoIterator<Item=T>>(mut self, allowed_roles: It) -> Self {
         self.0.allowed_roles = allowed_roles.into_iter().map(|x| x.to_string()).collect();
 

--- a/src/framework/standard/help_commands.rs
+++ b/src/framework/standard/help_commands.rs
@@ -24,6 +24,7 @@
 //! [`with_embeds`]: fn.with_embeds.html
 
 use client::Context;
+#[cfg(feature = "cache")]
 use framework::standard::{has_correct_roles, has_correct_permissions};
 use model::channel::Message;
 use model::id::ChannelId;
@@ -55,6 +56,7 @@ fn remove_aliases(cmds: &HashMap<String, CommandOrAlias>) -> HashMap<&String, &I
 
 /// Checks whether a user is member of required roles
 /// and given the required permissions.
+#[cfg(feature = "cache")]
 pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
     if let Some(guild) = msg.guild() {
         let guild = guild.read();
@@ -92,6 +94,7 @@ pub fn has_all_requirements(cmd: &Arc<CommandOptions>, msg: &Message) -> bool {
 /// client.with_framework(StandardFramework::new()
 ///     .help(help_commands::with_embeds));
 /// ```
+#[cfg(feature = "cache")]
 pub fn with_embeds<H: BuildHasher>(
     _: &mut Context,
     msg: &Message,
@@ -335,6 +338,7 @@ pub fn with_embeds<H: BuildHasher>(
 /// client.with_framework(StandardFramework::new()
 ///     .help(help_commands::plain));
 /// ```
+#[cfg(feature = "cache")]
 pub fn plain<H: BuildHasher>(
     _: &mut Context,
     msg: &Message,

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -1095,7 +1095,7 @@ impl Framework for StandardFramework {
         self.user_id = user_id.0;
     }
 }
-#[cfg(feature="cache")]
+#[cfg(feature = "cache")]
 pub fn has_correct_permissions(command: &Arc<CommandOptions>, message: &Message) -> bool {
     if !command.required_permissions.is_empty() {
         if let Some(guild) = message.guild() {

--- a/src/framework/standard/mod.rs
+++ b/src/framework/standard/mod.rs
@@ -567,15 +567,19 @@ impl StandardFramework {
             } else if self.configuration.disabled_commands.contains(built) {
                 Some(DispatchError::CommandDisabled(built.to_string()))
             } else {
-                if !command.allowed_roles.is_empty() {
-                    if let Some(guild) = message.guild() {
-                        let guild = guild.read();
 
-                        if let Some(member) = guild.members.get(&message.author.id) {
-                            if let Ok(permissions) = member.permissions() {
-                                if !permissions.administrator()
-                                    && !has_correct_roles(command, &guild, member) {
-                                    return Some(DispatchError::LackingRole);
+                #[cfg(feature = "cache")] {
+                    if !command.allowed_roles.is_empty() {
+                        if let Some(guild) = message.guild() {
+                            let guild = guild.read();
+
+                            if let Some(member) = guild.members.get(&message.author.id) {
+                                if let Ok(permissions) = member.permissions() {
+
+                                    if !permissions.administrator()
+                                        && !has_correct_roles(command, &guild, member) {
+                                        return Some(DispatchError::LackingRole);
+                                    }
                                 }
                             }
                         }
@@ -1091,8 +1095,7 @@ impl Framework for StandardFramework {
         self.user_id = user_id.0;
     }
 }
-
-#[cfg(feature = "cache")]
+#[cfg(feature="cache")]
 pub fn has_correct_permissions(command: &Arc<CommandOptions>, message: &Message) -> bool {
     if !command.required_permissions.is_empty() {
         if let Some(guild) = message.guild() {
@@ -1106,7 +1109,6 @@ pub fn has_correct_permissions(command: &Arc<CommandOptions>, message: &Message)
     true
 }
 
-#[cfg(feature = "cache")]
 pub fn has_correct_roles(cmd: &Arc<CommandOptions>, guild: &Guild, member: &Member) -> bool {
     if cmd.allowed_roles.is_empty() {
         true


### PR DESCRIPTION
Some sections of the framework were relying on accessing the cache, otherwise the high rate-limits of one per second will be hit very easily.
For now, I would rather remove the functionality entirely.

Affected Serenity-functionality:
- method `allowed_roles` on `CreateCommand` and `CreateGroup`
- Help-features: `with_embeds` and `plain`

Nonetheless, behaviour should not change nor seems this to be breaking anything, someone without cache was not able to build in the first place.

It would be cool if people help testing this : ) 
Make sure to remove the cache-feature and turn off default features.