### PR TITLE
GuildId changes

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -212,6 +212,10 @@ pub fn create_channel(guild_id: u64, map: &Value) -> Result<GuildChannel> {
 
     serde_json::from_reader::<HyperResponse, GuildChannel>(response)
         .map_err(From::from)
+        .and_then(|mut channel| {
+            channel.guild_id = guild_id;
+            Ok(channel)
+        })
 }
 
 /// Creates an emoji in the given [`Guild`] with the given data.
@@ -1166,6 +1170,11 @@ pub fn get_channels(guild_id: u64) -> Result<Vec<GuildChannel>> {
 
     serde_json::from_reader::<HyperResponse, Vec<GuildChannel>>(response)
         .map_err(From::from)
+        .and_then(|mut channels| {
+            for channel in channels.iter_mut() {
+                channel.guild_id = guild_id;
+            }
+        })
 }
 
 /// Gets information about the current application.
@@ -1275,19 +1284,18 @@ pub fn get_guild_members(guild_id: u64,
         after.unwrap_or(0)
     );
 
-    let mut v = serde_json::from_reader::<HyperResponse, Value>(response)?;
-
-    if let Some(values) = v.as_array_mut() {
-        let num = Value::Number(Number::from(guild_id));
-
-        for value in values {
-            if let Some(element) = value.as_object_mut() {
-                element.insert("guild_id".to_string(), num.clone());
+    let gid = GuildId(guild_id);
+    let v = serde_json::from_reader::<HyperResponse, Value>(response)?;
+    
+    serde_json::from_value::<Vec<Member>>(v)
+        .map_err(From::from)
+        .and_then(|mut members| {
+            for member in members.iter_mut() {
+                member.guild_id = gid;
             }
-        }
-    }
 
-    serde_json::from_value::<Vec<Member>>(v).map_err(From::from)
+            Ok(members)
+        })
 }
 
 /// Gets the amount of users that can be pruned.
@@ -1433,13 +1441,14 @@ pub fn get_member(guild_id: u64, user_id: u64) -> Result<Member> {
         user_id
     );
 
-    let mut v = serde_json::from_reader::<HyperResponse, Value>(response)?;
+    let v = serde_json::from_reader::<HyperResponse, Value>(response)?;
 
-    if let Some(map) = v.as_object_mut() {
-        map.insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
-    }
-
-    serde_json::from_value::<Member>(v).map_err(From::from)
+    serde_json::from_value::<Member>(v)
+        .map_err(From::from)
+        .and_then(|mut member| {
+            member.guild_id = GuildId(guild_id);
+            Ok(member)
+        })
 }
 
 /// Gets a message by an Id, bots only.

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -213,7 +213,7 @@ pub fn create_channel(guild_id: u64, map: &Value) -> Result<GuildChannel> {
     serde_json::from_reader::<HyperResponse, GuildChannel>(response)
         .map_err(From::from)
         .and_then(|mut channel| {
-            channel.guild_id = guild_id;
+            channel.guild_id = GuildId(guild_id);
             Ok(channel)
         })
 }
@@ -1168,12 +1168,16 @@ pub fn get_channels(guild_id: u64) -> Result<Vec<GuildChannel>> {
         guild_id
     );
 
+    let gid = GuildId(guild_id);
+
     serde_json::from_reader::<HyperResponse, Vec<GuildChannel>>(response)
         .map_err(From::from)
         .and_then(|mut channels| {
             for channel in channels.iter_mut() {
-                channel.guild_id = guild_id;
+                channel.guild_id = gid;
             }
+
+            Ok(channels)
         })
 }
 

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -37,6 +37,7 @@ pub struct GuildChannel {
     ///
     /// The original voice channel has an Id equal to the guild's Id,
     /// incremented by one.
+    #[serde(skip_deserializing)]
     pub guild_id: GuildId,
     /// The type of the channel.
     #[serde(rename = "type")]

--- a/src/model/guild/member.rs
+++ b/src/model/guild/member.rs
@@ -54,6 +54,7 @@ pub struct Member {
     /// Indicator of whether the member can hear in voice channels.
     pub deaf: bool,
     /// The unique Id of the guild that the member is a part of.
+    #[serde(skip_deserializing)]
     pub guild_id: GuildId,
     /// Timestamp representing the date when the member joined.
     pub joined_at: Option<DateTime<FixedOffset>>,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1627,10 +1627,13 @@ impl<'de> Deserialize<'de> for Guild {
             .ok_or_else(|| DeError::custom("expected guild region"))
             .and_then(String::deserialize)
             .map_err(DeError::custom)?;
-        let roles = map.remove("roles")
+        let mut roles = map.remove("roles")
             .ok_or_else(|| DeError::custom("expected guild roles"))
             .and_then(deserialize_roles)
             .map_err(DeError::custom)?;
+        for (_, role) in roles.iter_mut() {
+            role.guild_id = id;
+        }
         let splash = match map.remove("splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
             None => None,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1521,29 +1521,10 @@ impl<'de> Deserialize<'de> for Guild {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> StdResult<Self, D::Error> {
         let mut map = JsonMap::deserialize(deserializer)?;
 
-        let id = map.get("id")
-            .and_then(|x| x.as_str())
-            .and_then(|x| x.parse::<u64>().ok());
-
-        if let Some(guild_id) = id {
-            if let Some(array) = map.get_mut("channels").and_then(|x| x.as_array_mut()) {
-                for value in array {
-                    if let Some(channel) = value.as_object_mut() {
-                        channel
-                            .insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
-                    }
-                }
-            }
-
-            if let Some(array) = map.get_mut("members").and_then(|x| x.as_array_mut()) {
-                for value in array {
-                    if let Some(member) = value.as_object_mut() {
-                        member
-                            .insert("guild_id".to_string(), Value::Number(Number::from(guild_id)));
-                    }
-                }
-            }
-        }
+        let id = map.remove("id")
+            .ok_or_else(|| DeError::custom("expected guild id"))
+            .and_then(GuildId::deserialize)
+            .map_err(DeError::custom)?;
 
         let afk_channel_id = match map.remove("afk_channel_id") {
             Some(v) => serde_json::from_value::<Option<ChannelId>>(v)
@@ -1587,10 +1568,6 @@ impl<'de> Deserialize<'de> for Guild {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
             None => None,
         };
-        let id = map.remove("id")
-            .ok_or_else(|| DeError::custom("expected guild id"))
-            .and_then(GuildId::deserialize)
-            .map_err(DeError::custom)?;
         let joined_at = map.remove("joined_at")
             .ok_or_else(|| DeError::custom("expected guild joined_at"))
             .and_then(DateTime::deserialize)
@@ -1603,7 +1580,7 @@ impl<'de> Deserialize<'de> for Guild {
             .ok_or_else(|| DeError::custom("expected guild member_count"))
             .and_then(u64::deserialize)
             .map_err(DeError::custom)?;
-        let members = map.remove("members")
+        let mut members = map.remove("members")
             .ok_or_else(|| DeError::custom("expected guild members"))
             .and_then(deserialize_members)
             .map_err(DeError::custom)?;
@@ -1631,9 +1608,6 @@ impl<'de> Deserialize<'de> for Guild {
             .ok_or_else(|| DeError::custom("expected guild roles"))
             .and_then(deserialize_roles)
             .map_err(DeError::custom)?;
-        for (_, role) in roles.iter_mut() {
-            role.guild_id = id;
-        }
         let splash = match map.remove("splash") {
             Some(v) => Option::<String>::deserialize(v).map_err(DeError::custom)?,
             None => None,
@@ -1650,6 +1624,19 @@ impl<'de> Deserialize<'de> for Guild {
             .ok_or_else(|| DeError::custom("expected guild voice_states"))
             .and_then(deserialize_voice_states)
             .map_err(DeError::custom)?;
+
+
+        for (_, channel) in &channels {
+            channel.write().guild_id = id;
+        }
+
+        for (_, member) in members.iter_mut() {
+            member.guild_id = id;
+        }
+
+        for (_, role) in roles.iter_mut() {
+            role.guild_id = id;
+        }
 
         Ok(Self {
             afk_channel_id: afk_channel_id,

--- a/src/model/guild/mod.rs
+++ b/src/model/guild/mod.rs
@@ -1625,7 +1625,6 @@ impl<'de> Deserialize<'de> for Guild {
             .and_then(deserialize_voice_states)
             .map_err(DeError::custom)?;
 
-
         for (_, channel) in &channels {
             channel.write().guild_id = id;
         }

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -70,7 +70,7 @@ impl Role {
     ///
     /// [Manage Roles]: permissions/constant.MANAGE_ROLES.html
     #[inline]
-    pub fn delete(&self) -> Result<()> { http::delete_role(self.guild_id().0, self.id.0) }
+    pub fn delete(&self) -> Result<()> { http::delete_role(self.guild_id.0, self.id.0) }
 
     /// Edits a [`Role`], optionally setting its new fields.
     ///
@@ -115,11 +115,6 @@ impl Role {
         }
 
         Err(Error::Model(ModelError::GuildNotFound))
-    }
-
-    /// Get the id of the guild that owns this role.
-    pub fn guild_id(&self) -> GuildId {
-        self.guild_id
     }
 
     /// Check that the role has the given permission.

--- a/src/model/guild/role.rs
+++ b/src/model/guild/role.rs
@@ -57,6 +57,9 @@ pub struct Role {
     ///
     /// The `@everyone` role is usually either `-1` or `0`.
     pub position: i64,
+    /// The guild id that this role is associated with.
+    #[serde(skip)]
+    pub guild_id: GuildId,
 }
 
 #[cfg(feature = "model")]
@@ -66,9 +69,8 @@ impl Role {
     /// **Note** Requires the [Manage Roles] permission.
     ///
     /// [Manage Roles]: permissions/constant.MANAGE_ROLES.html
-    #[cfg(feature = "cache")]
     #[inline]
-    pub fn delete(&self) -> Result<()> { http::delete_role(self.find_guild()?.0, self.id.0) }
+    pub fn delete(&self) -> Result<()> { http::delete_role(self.guild_id().0, self.id.0) }
 
     /// Edits a [`Role`], optionally setting its new fields.
     ///
@@ -90,8 +92,7 @@ impl Role {
     /// [Manage Roles]: permissions/constant.MANAGE_ROLES.html
     #[cfg(all(feature = "builder", feature = "cache"))]
     pub fn edit<F: FnOnce(EditRole) -> EditRole>(&self, f: F) -> Result<Role> {
-        self.find_guild()
-            .and_then(|guild_id| guild_id.edit_role(self.id, f))
+        self.guild_id.edit_role(self.id, f)
     }
 
     /// Searches the cache for the guild that owns the role.
@@ -103,6 +104,7 @@ impl Role {
     ///
     /// [`ModelError::GuildNotFound`]: enum.ModelError.html#variant.GuildNotFound
     #[cfg(feature = "cache")]
+    #[deprecated(since="0.6.0", note="Replaced by `guild_id`")]
     pub fn find_guild(&self) -> Result<GuildId> {
         for guild in CACHE.read().guilds.values() {
             let guild = guild.read();
@@ -113,6 +115,11 @@ impl Role {
         }
 
         Err(Error::Model(ModelError::GuildNotFound))
+    }
+
+    /// Get the id of the guild that owns this role.
+    pub fn guild_id(&self) -> GuildId {
+        self.guild_id
     }
 
     /// Check that the role has the given permission.

--- a/src/utils/colour.rs
+++ b/src/utils/colour.rs
@@ -29,11 +29,12 @@ macro_rules! colour {
 ///
 /// ```rust
 /// # use serenity::model::guild::Role;
-/// # use serenity::model::id::RoleId;
+/// # use serenity::model::id::{GuildId, RoleId};
 /// # use serenity::model::permissions;
 /// #
 /// # let role = Role {
 /// #     colour: Colour::blurple(),
+/// #     guild_id: GuildId(2),
 /// #     hoist: false,
 /// #     id: RoleId(1),
 /// #     managed: false,

--- a/tests/test_formatters.rs
+++ b/tests/test_formatters.rs
@@ -45,6 +45,7 @@ fn test_mention() {
     let role = Role {
         id: RoleId(2),
         colour: Colour::rosewater(),
+        guild_id: GuildId(2),
         hoist: false,
         managed: false,
         mentionable: false,


### PR DESCRIPTION
Attempting to address issue #167 

`Role`, `GuildChannel`, and `Member` will no longer deserialize with a guild id. Instead, they will now get their guild id's assigned from the `Guild` deserializer after the rest of the struct is deserialized.

Also GuildRoleCreateEvent has a new custom deserializer that assigns the guild id to the associated role.