### PR TITLE
fix: don't include optional params if left blank in audit logs

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1060,16 +1060,32 @@ pub fn get_audit_logs(guild_id: u64,
                       user_id: Option<u64>,
                       before: Option<u64>,
                       limit: Option<u8>) -> Result<AuditLogs> {
+    let mut params = Vec::with_capacity(4);
+
+    if let Some(action_type) = action_type {
+        params.push(format!("action_type={}", action_type));
+    }
+    if let Some(user_id) = user_id {
+        params.push(format!("user_id={}", user_id));
+    }
+    if let Some(before) = before {
+        params.push(format!("before={}", before));
+    }
+    if let Some(limit) = limit {
+        params.push(format!("limit={}", limit));
+    }
+
+    let mut query_string = params.join("&");
+    if !query_string.is_empty() {
+        query_string.insert(0, '?');
+    }
+
     let response = request!(
         Route::GuildsIdAuditLogs(guild_id),
         get,
-        "/guilds/{}/audit-logs?user_id={}&action_type={}&before={}&limit={}",
+        "/guilds/{}/audit-logs{}",
         guild_id,
-        user_id.unwrap_or(0),
-        action_type.unwrap_or(0),
-        before.unwrap_or(0),
-        limit.unwrap_or(50),
-    );
+        query_string);
 
     serde_json::from_reader::<HyperResponse, AuditLogs>(response)
         .map_err(From::from)

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -1085,7 +1085,8 @@ pub fn get_audit_logs(guild_id: u64,
         get,
         "/guilds/{}/audit-logs{}",
         guild_id,
-        query_string);
+        query_string
+    );
 
     serde_json::from_reader::<HyperResponse, AuditLogs>(response)
         .map_err(From::from)


### PR DESCRIPTION
See #302.