### PR TITLE
Send silence frames upon connection (Fix #301)

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,6 +45,8 @@ pub static JOIN_MESSAGES: &'static [&'static str] = &[
     "$user just showed up. Hold my beer.",
 ];
 
+pub static SILENT_FRAME: [u8; 3] = [0xf8,0xff,0xfe];
+
 /// Enum to map gateway opcodes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum OpCode {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -45,8 +45,6 @@ pub static JOIN_MESSAGES: &'static [&'static str] = &[
     "$user just showed up. Hold my beer.",
 ];
 
-pub static SILENT_FRAME: [u8; 3] = [0xf8,0xff,0xfe];
-
 /// Enum to map gateway opcodes.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub enum OpCode {

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -6,6 +6,7 @@ use std::{
 
 pub const HEADER_LEN: usize = 12;
 pub const SAMPLE_RATE: u32 = 48_000;
+pub static SILENT_FRAME: [u8; 3] = [0xf8,0xff,0xfe];
 
 /// A readable audio source.
 pub trait AudioSource: Send {

--- a/src/voice/audio.rs
+++ b/src/voice/audio.rs
@@ -6,7 +6,7 @@ use std::{
 
 pub const HEADER_LEN: usize = 12;
 pub const SAMPLE_RATE: u32 = 48_000;
-pub static SILENT_FRAME: [u8; 3] = [0xf8,0xff,0xfe];
+pub static SILENT_FRAME: [u8; 3] = [0xf8, 0xff, 0xfe];
 
 /// A readable audio source.
 pub trait AudioSource: Send {

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -5,7 +5,7 @@ use byteorder::{
     ReadBytesExt, 
     WriteBytesExt
 };
-use constants::{VOICE_GATEWAY_VERSION, SILENT_FRAME};
+use constants::VOICE_GATEWAY_VERSION;
 use internal::prelude::*;
 use internal::{
     ws_impl::{ReceiverExt, SenderExt},
@@ -45,7 +45,7 @@ use std::{
     },
     time::Duration
 };
-use super::audio::{AudioReceiver, AudioType, HEADER_LEN, SAMPLE_RATE, LockedAudio};
+use super::audio::{AudioReceiver, AudioType, LockedAudio, HEADER_LEN, SAMPLE_RATE, SILENT_FRAME};
 use super::connection_info::ConnectionInfo;
 use super::{payload, VoiceError, CRYPTO_MODE};
 use websocket::{

--- a/src/voice/connection.rs
+++ b/src/voice/connection.rs
@@ -5,7 +5,7 @@ use byteorder::{
     ReadBytesExt, 
     WriteBytesExt
 };
-use constants::VOICE_GATEWAY_VERSION;
+use constants::{VOICE_GATEWAY_VERSION, SILENT_FRAME};
 use internal::prelude::*;
 use internal::{
     ws_impl::{ReceiverExt, SenderExt},
@@ -200,7 +200,8 @@ impl Connection {
             keepalive_timer: Timer::new(temp_heartbeat),
             udp,
             sequence: 0,
-            silence_frames: 0,
+            // We need to send some frames to receive any audio.
+            silence_frames: 100,
             soft_clip,
             speaking: false,
             ssrc: hello.ssrc,
@@ -392,7 +393,7 @@ impl Connection {
                 self.silence_frames -= 1;
 
                 // Explicit "Silence" frame.
-                opus_frame.extend_from_slice(&[0xf8, 0xff, 0xfe]);
+                opus_frame.extend_from_slice(&SILENT_FRAME);
             } else {
                 // Per official guidelines, send 5x silence BEFORE we stop speaking.
                 self.set_speaking(false)?;


### PR DESCRIPTION
* Sends 100 empty frames at discord upon connection.
* Moves silent frame def out into the constants file (named).

Works for both Example 10 and the modified version of my own bot.