### PR TITLE
Fix voice hang on Audio `.stop()`.

### DIFF
--- a/src/voice/streamer.rs
+++ b/src/voice/streamer.rs
@@ -35,7 +35,7 @@ impl Read for ChildContainer {
 
 impl Drop for ChildContainer {
     fn drop (&mut self) {
-        if let Err(e) = self.0.wait() {
+        if let Err(e) = self.0.kill() {
             debug!("[Voice] Error awaiting child process: {:?}", e);
         }
     }


### PR DESCRIPTION
Turns out `wait` was a little *too* cooperative. Waiting on an audio stream that hadn't yet finished (i.e., killing all existing sounds) caused the voice thread to hang since ffmpeg would never terminate...

Holdover until we change to real ffmpeg bindings.